### PR TITLE
Dynamically import platform bridges based on platformId

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "One SDK for cross-platform publishing HTML5 games",
     "main": "index.js",
     "scripts": {
-        "build": "webpack",
+        "build": "npm run build:bundled",
         "build:dynamic": "webpack --config-name dynamic",
         "build:bundled": "webpack --config-name bundled",
         "develop": "webpack --mode=development",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
     "main": "index.js",
     "scripts": {
         "build": "webpack",
+        "build:dynamic": "webpack --config-name dynamic",
+        "build:bundled": "webpack --config-name bundled",
         "develop": "webpack --mode=development",
-        "dev": "webpack serve --mode=development",
+        "dev": "webpack serve --mode=development --config-name dynamic",
         "test": "vitest run",
         "test:watch": "vitest",
         "lint": "eslint src/",

--- a/src/PlaygamaBridge.js
+++ b/src/PlaygamaBridge.js
@@ -46,31 +46,7 @@ import RemoteConfigModule from './modules/RemoteConfigModule'
 import ClipboardModule from './modules/ClipboardModule'
 import AchievementsModule from './modules/AchievementsModule'
 import analyticsModule from './modules/AnalyticsModule'
-import PlatformBridgeBase from './platform-bridges/PlatformBridgeBase'
-import VkPlatformBridge from './platform-bridges/VkPlatformBridge'
-import YandexPlatformBridge from './platform-bridges/YandexPlatformBridge'
-import CrazyGamesPlatformBridge from './platform-bridges/CrazyGamesPlatformBridge'
-import AbsoluteGamesPlatformBridge from './platform-bridges/AbsoluteGamesPlatformBridge'
-import GameDistributionPlatformBridge from './platform-bridges/GameDistributionPlatformBridge'
-import OkPlatformBridge from './platform-bridges/OkPlatformBridge'
-import PlaygamaPlatformBridge from './platform-bridges/PlaygamaPlatformBridge'
-import PlayDeckPlatformBridge from './platform-bridges/PlayDeckPlatformBridge'
-import TelegramPlatformBridge from './platform-bridges/TelegramPlatformBridge'
-import Y8PlatformBridge from './platform-bridges/Y8PlatformBridge'
-import LaggedPlatformBridge from './platform-bridges/LaggedPlatformBridge'
-import FacebookPlatformBridge from './platform-bridges/FacebookPlatformBridge'
-import QaToolPlatformBridge from './platform-bridges/QaToolPlatformBridge'
-import PokiPlatformBridge from './platform-bridges/PokiPlatformBridge'
-import MsnPlatformBridge from './platform-bridges/MsnPlatformBridge'
-import HuaweiPlatformBridge from './platform-bridges/HuaweiPlatformBridge'
-import BitquestPlatformBridge from './platform-bridges/BitquestPlatformBridge'
-import GamePushPlatformBridge from './platform-bridges/GamePushPlatformBridge'
-import DiscordPlatformBridge from './platform-bridges/DiscordPlatformBridge'
-import YoutubePlatformBridge from './platform-bridges/YoutubePlatformBridge'
-import JioGamesPlatformBridge from './platform-bridges/JioGamesPlatformBridge'
-import PortalPlatformBridge from './platform-bridges/PortalPlatformBridge'
-import RedditPlatformBridge from './platform-bridges/RedditPlatformBridge'
-import XiaomiPlatformBridge from './platform-bridges/XiaomiPlatformBridge'
+import { fetchPlatformBridge } from './platformImports'
 
 class PlaygamaBridge {
     get version() {
@@ -215,7 +191,7 @@ class PlaygamaBridge {
             const configFilePath = options?.configFilePath
             await configFileModule.load(configFilePath, options)
 
-            this.#createPlatformBridge()
+            await this.#createPlatformBridge()
 
             this.#platformBridge.engine = this.engine
 
@@ -279,7 +255,7 @@ class PlaygamaBridge {
         return this.#initializationPromiseDecorator.promise
     }
 
-    #createPlatformBridge() {
+    async #createPlatformBridge() {
         let platformId = PLATFORM_ID.MOCK
 
         const url = new URL(window.location.href)
@@ -329,108 +305,8 @@ class PlaygamaBridge {
             }
         }
 
-        switch (platformId) {
-            case PLATFORM_ID.VK: {
-                this.#platformBridge = new VkPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.YANDEX: {
-                this.#platformBridge = new YandexPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.CRAZY_GAMES: {
-                this.#platformBridge = new CrazyGamesPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.ABSOLUTE_GAMES: {
-                this.#platformBridge = new AbsoluteGamesPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.GAME_DISTRIBUTION: {
-                this.#platformBridge = new GameDistributionPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.OK: {
-                this.#platformBridge = new OkPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.PLAYGAMA: {
-                this.#platformBridge = new PlaygamaPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.PLAYDECK: {
-                this.#platformBridge = new PlayDeckPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.TELEGRAM: {
-                this.#platformBridge = new TelegramPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.Y8: {
-                this.#platformBridge = new Y8PlatformBridge()
-                break
-            }
-            case PLATFORM_ID.LAGGED: {
-                this.#platformBridge = new LaggedPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.FACEBOOK: {
-                this.#platformBridge = new FacebookPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.POKI: {
-                this.#platformBridge = new PokiPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.QA_TOOL: {
-                this.#platformBridge = new QaToolPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.MSN: {
-                this.#platformBridge = new MsnPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.HUAWEI: {
-                this.#platformBridge = new HuaweiPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.BITQUEST: {
-                this.#platformBridge = new BitquestPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.GAMEPUSH: {
-                this.#platformBridge = new GamePushPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.DISCORD: {
-                this.#platformBridge = new DiscordPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.YOUTUBE: {
-                this.#platformBridge = new YoutubePlatformBridge()
-                break
-            }
-            case PLATFORM_ID.JIO_GAMES: {
-                this.#platformBridge = new JioGamesPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.PORTAL: {
-                this.#platformBridge = new PortalPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.REDDIT: {
-                this.#platformBridge = new RedditPlatformBridge()
-                break
-            }
-            case PLATFORM_ID.XIAOMI: {
-                this.#platformBridge = new XiaomiPlatformBridge()
-                break
-            }
-            default: {
-                this.#platformBridge = new PlatformBridgeBase()
-                break
-            }
-        }
+        const PlatformBridge = await fetchPlatformBridge(platformId)
+        this.#platformBridge = new PlatformBridge()
     }
 
     #getPlatformId(value) {

--- a/src/platformImports.js
+++ b/src/platformImports.js
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Playgama Bridge.
+ *
+ * Playgama Bridge is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Playgama Bridge is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Playgama Bridge. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import { PLATFORM_ID } from './constants'
+import PlatformBridgeBase from './platform-bridges/PlatformBridgeBase'
+
+const platformImports = {
+    [PLATFORM_ID.VK]: () => import('./platform-bridges/VkPlatformBridge'),
+    [PLATFORM_ID.YANDEX]: () => import('./platform-bridges/YandexPlatformBridge'),
+    [PLATFORM_ID.CRAZY_GAMES]: () => import('./platform-bridges/CrazyGamesPlatformBridge'),
+    [PLATFORM_ID.ABSOLUTE_GAMES]: () => import('./platform-bridges/AbsoluteGamesPlatformBridge'),
+    [PLATFORM_ID.GAME_DISTRIBUTION]: () => import('./platform-bridges/GameDistributionPlatformBridge'),
+    [PLATFORM_ID.OK]: () => import('./platform-bridges/OkPlatformBridge'),
+    [PLATFORM_ID.PLAYGAMA]: () => import('./platform-bridges/PlaygamaPlatformBridge'),
+    [PLATFORM_ID.PLAYDECK]: () => import('./platform-bridges/PlayDeckPlatformBridge'),
+    [PLATFORM_ID.TELEGRAM]: () => import('./platform-bridges/TelegramPlatformBridge'),
+    [PLATFORM_ID.Y8]: () => import('./platform-bridges/Y8PlatformBridge'),
+    [PLATFORM_ID.LAGGED]: () => import('./platform-bridges/LaggedPlatformBridge'),
+    [PLATFORM_ID.FACEBOOK]: () => import('./platform-bridges/FacebookPlatformBridge'),
+    [PLATFORM_ID.POKI]: () => import('./platform-bridges/PokiPlatformBridge'),
+    [PLATFORM_ID.QA_TOOL]: () => import('./platform-bridges/QaToolPlatformBridge'),
+    [PLATFORM_ID.MSN]: () => import('./platform-bridges/MsnPlatformBridge'),
+    [PLATFORM_ID.HUAWEI]: () => import('./platform-bridges/HuaweiPlatformBridge'),
+    [PLATFORM_ID.BITQUEST]: () => import('./platform-bridges/BitquestPlatformBridge'),
+    [PLATFORM_ID.GAMEPUSH]: () => import('./platform-bridges/GamePushPlatformBridge'),
+    [PLATFORM_ID.DISCORD]: () => import('./platform-bridges/DiscordPlatformBridge'),
+    [PLATFORM_ID.YOUTUBE]: () => import('./platform-bridges/YoutubePlatformBridge'),
+    [PLATFORM_ID.JIO_GAMES]: () => import('./platform-bridges/JioGamesPlatformBridge'),
+    [PLATFORM_ID.PORTAL]: () => import('./platform-bridges/PortalPlatformBridge'),
+    [PLATFORM_ID.REDDIT]: () => import('./platform-bridges/RedditPlatformBridge'),
+    [PLATFORM_ID.XIAOMI]: () => import('./platform-bridges/XiaomiPlatformBridge'),
+}
+
+export async function fetchPlatformBridge(platformId) {
+    const importPlatform = platformImports[platformId]
+    if (importPlatform) {
+        const { default: PlatformBridge } = await importPlatform()
+        return PlatformBridge
+    }
+    return PlatformBridgeBase
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,13 +1,37 @@
 const path = require('path')
 const webpack = require('webpack')
 const ESLintPlugin = require('eslint-webpack-plugin')
+const TerserPlugin = require('terser-webpack-plugin')
 const packageJson = require('./package.json')
 
 module.exports = {
     entry: './src/index.js',
     output: {
         filename: 'playgama-bridge.js',
+        chunkFilename: (pathData) => {
+            const chunkId = String(pathData.chunk.id || pathData.chunk.name || '')
+            const match = chunkId.match(/platform-bridges_(\w+)_js/)
+
+            if (match) {
+                const name = match[1]
+                    .replace(/PlatformBridge/, '')
+                    .replace(/([A-Z])/g, '-$1')
+                    .toLowerCase()
+                    .replace(/^-/, '')
+                return `platforms-bridges/${name}.platform-bridge.js`
+            }
+            return `platforms-bridges/${chunkId}.js`
+        },
         path: path.resolve(__dirname, 'dist'),
+        publicPath: 'auto',
+        clean: {
+            keep: (asset) => {
+                if (asset.startsWith('platforms-bridges/')) {
+                    return false
+                }
+                return true
+            },
+        },
     },
     module: {
         rules: [
@@ -22,6 +46,21 @@ module.exports = {
                 },
             },
         ],
+    },
+    optimization: {
+        chunkIds: 'named',
+        minimizer: [
+            new TerserPlugin({
+                extractComments: false,
+            }),
+        ],
+        splitChunks: {
+            chunks: 'async',
+            cacheGroups: {
+                default: false,
+                defaultVendors: false,
+            },
+        },
     },
     plugins: [
         new ESLintPlugin(),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,9 @@ const ESLintPlugin = require('eslint-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const packageJson = require('./package.json')
 
-module.exports = {
+const dynamicConfig = {
+    name: 'dynamic',
+    mode: 'production',
     entry: './src/index.js',
     output: {
         filename: 'playgama-bridge.js',
@@ -52,6 +54,11 @@ module.exports = {
         minimizer: [
             new TerserPlugin({
                 extractComments: false,
+                terserOptions: {
+                    format: {
+                        comments: false,
+                    },
+                },
             }),
         ],
         splitChunks: {
@@ -73,3 +80,21 @@ module.exports = {
         port: 3535,
     },
 }
+
+// Bundled build - everything in one file
+const bundledConfig = {
+    ...dynamicConfig,
+    name: 'bundled',
+    output: {
+        ...dynamicConfig.output,
+        filename: 'playgama-bridge.bundled.js',
+    },
+    plugins: [
+        ...dynamicConfig.plugins,
+        new webpack.optimize.LimitChunkCountPlugin({
+            maxChunks: 1,
+        }),
+    ],
+}
+
+module.exports = [dynamicConfig, bundledConfig]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ const dynamicConfig = {
                     .replace(/([A-Z])/g, '-$1')
                     .replace(/-/g, '')
                     .toLowerCase()
-                return `${platformDirName}/${name}.platform.js`
+                return `${platformDirName}/${name}.js`
             }
             return `${platformDirName}/${chunkId}.js`
         },


### PR DESCRIPTION
- Replaced static imports of platform bridges with a single import statement that dynamically loads the appropriate platform bridge based on the platformId.
- Updated the #createPlatformBridge method to be asynchronous, ensuring proper handling of the dynamic imports.
- Simplified platform bridge initialization logic, improving maintainability and reducing code duplication.