### PR TITLE
Add RecorderModule for QaTool platform with WebRTC capture and screenshot support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  install:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - uses: actions/cache/save@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+
+  lint:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+      - run: npm run lint
+
+  test:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+      - run: npm test
+
+  build:
+    needs: install
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - uses: actions/cache/restore@v4
+        with:
+          path: node_modules
+          key: node-modules-${{ hashFiles('package-lock.json') }}
+      - run: npm run build

--- a/src/constants.js
+++ b/src/constants.js
@@ -65,6 +65,7 @@ export const MODULE_NAME = {
     CLIPBOARD: 'clipboard',
     ACHIEVEMENTS: 'achievements',
     ANALYTICS: 'analytics',
+    RECORDER: 'recorder',
 }
 
 export const EVENT_NAME = {

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -28,14 +28,22 @@ class RecorderModule {
 
     #onError = null
 
+    /** @param {function(string): void} fn - Called with SDP offer string */
     set onOffer(fn) { this.#onOffer = fn }
 
+    /** @param {function(RTCIceCandidateInit): void} fn - Called with ICE candidate JSON */
     set onIceCandidate(fn) { this.#onIceCandidate = fn }
 
+    /** @param {function(): void} fn - Called when capture has started */
     set onStarted(fn) { this.#onStarted = fn }
 
+    /** @param {function(string): void} fn - Called with error message */
     set onError(fn) { this.#onError = fn }
 
+    /**
+     * Checks whether WebRTC streaming is available in the current environment.
+     * @returns {{ available: boolean, reason: string | null }}
+     */
     checkAvailability() {
         if (!this.#isWebRTCSupported()) {
             return { available: false, reason: 'RTCPeerConnection is not supported' }
@@ -49,7 +57,19 @@ class RecorderModule {
         return { available: true, reason: null }
     }
 
-    async startCapture({ fps = 30 } = {}) {
+    /**
+     * Starts canvas capture and creates a WebRTC offer.
+     * @param {Object} [options]
+     * @param {number} [options.fps=30] - Capture frame rate passed to captureStream()
+     * @param {number} [options.maxBitrate] - Maximum bitrate in bits/s
+     * @param {number} [options.minBitrate] - Minimum bitrate in bits/s
+     * @param {number} [options.maxFramerate] - Maximum framerate at encoding level
+     * @param {number} [options.scaleResolutionDownBy] - Resolution scale-down factor (e.g. 2.0 = half)
+     * @param {'very-low'|'low'|'medium'|'high'} [options.priority] - Encoding priority
+     * @param {'very-low'|'low'|'medium'|'high'} [options.networkPriority] - Network-level priority
+     * @param {string} [options.scalabilityMode] - SVC scalability mode (e.g. "L1T3")
+     */
+    async startCapture(options = {}) {
         const { available, reason } = this.checkAvailability()
         if (!available) {
             this.#onError?.(reason)
@@ -58,7 +78,7 @@ class RecorderModule {
 
         const canvas = this.#getCanvas()
 
-        this.#stream = canvas.captureStream(fps)
+        this.#stream = canvas.captureStream(options.fps || 30)
         this.#pc = new RTCPeerConnection()
 
         this.#stream.getTracks().forEach((t) => this.#pc.addTrack(t, this.#stream))
@@ -71,10 +91,29 @@ class RecorderModule {
 
         const offer = await this.#pc.createOffer()
         await this.#pc.setLocalDescription(offer)
+
+        const hasEncodingParams = [
+            options.maxBitrate,
+            options.minBitrate,
+            options.maxFramerate,
+            options.scaleResolutionDownBy,
+            options.priority,
+            options.networkPriority,
+            options.scalabilityMode,
+        ].some((v) => v !== undefined)
+        if (hasEncodingParams) {
+            this.#applyEncodingParams(options)
+        }
+
         this.#onOffer?.(offer.sdp)
         this.#onStarted?.()
     }
 
+    /**
+     * Sets the remote SDP answer on the peer connection.
+     * @param {Object} params
+     * @param {string} params.sdp - Remote SDP answer string
+     */
     async handleAnswer({ sdp }) {
         if (this.#pc) {
             await this.#pc.setRemoteDescription(
@@ -83,12 +122,23 @@ class RecorderModule {
         }
     }
 
+    /**
+     * Adds a remote ICE candidate to the peer connection.
+     * @param {RTCIceCandidateInit | null} candidate
+     */
     async handleIce(candidate) {
         if (this.#pc && candidate) {
             await this.#pc.addIceCandidate(new RTCIceCandidate(candidate))
         }
     }
 
+    /**
+     * Takes a screenshot of the current canvas.
+     * @param {Object} [options]
+     * @param {string} [options.type='image/png'] - Image MIME type
+     * @param {number} [options.quality=0.92] - Image quality (0–1)
+     * @returns {{ success: boolean, reason: string | null, data: string | null }}
+     */
     takeScreenshot({ type = 'image/png', quality = 0.92 } = {}) {
         const canvas = this.#getCanvas()
         if (!canvas) {
@@ -98,11 +148,38 @@ class RecorderModule {
         return { success: true, reason: null, data }
     }
 
+    /** Stops the capture, closes the peer connection and releases all tracks. */
     stopCapture() {
         this.#stream?.getTracks().forEach((t) => t.stop())
         this.#pc?.close()
         this.#pc = null
         this.#stream = null
+    }
+
+    #applyEncodingParams({
+        maxBitrate,
+        minBitrate,
+        maxFramerate,
+        scaleResolutionDownBy,
+        priority,
+        networkPriority,
+        scalabilityMode,
+    }) {
+        this.#pc.getSenders().forEach((sender) => {
+            if (sender.track?.kind !== 'video') return
+            const params = sender.getParameters()
+            if (!params.encodings?.length) {
+                params.encodings = [{}]
+            }
+            if (maxBitrate !== undefined) params.encodings[0].maxBitrate = maxBitrate
+            if (minBitrate !== undefined) params.encodings[0].minBitrate = minBitrate
+            if (maxFramerate !== undefined) params.encodings[0].maxFramerate = maxFramerate
+            if (scaleResolutionDownBy !== undefined) params.encodings[0].scaleResolutionDownBy = scaleResolutionDownBy
+            if (priority !== undefined) params.encodings[0].priority = priority
+            if (networkPriority !== undefined) params.encodings[0].networkPriority = networkPriority
+            if (scalabilityMode !== undefined) params.encodings[0].scalabilityMode = scalabilityMode
+            sender.setParameters(params)
+        })
     }
 
     #getCanvas() {

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -1,0 +1,122 @@
+/*
+ * This file is part of Playgama Bridge.
+ *
+ * Playgama Bridge is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Playgama Bridge is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Playgama Bridge. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+class RecorderModule {
+    #pc = null
+
+    #stream = null
+
+    #onOffer = null
+
+    #onIceCandidate = null
+
+    #onStarted = null
+
+    #onError = null
+
+    set onOffer(fn) { this.#onOffer = fn }
+
+    set onIceCandidate(fn) { this.#onIceCandidate = fn }
+
+    set onStarted(fn) { this.#onStarted = fn }
+
+    set onError(fn) { this.#onError = fn }
+
+    checkAvailability() {
+        if (!this.#isWebRTCSupported()) {
+            return { available: false, reason: 'RTCPeerConnection is not supported' }
+        }
+        if (!this.#isCaptureStreamSupported()) {
+            return { available: false, reason: 'captureStream is not supported' }
+        }
+        if (!this.#getCanvas()) {
+            return { available: false, reason: 'Canvas not found' }
+        }
+        return { available: true, reason: null }
+    }
+
+    async startCapture({ fps = 30 } = {}) {
+        const { available, reason } = this.checkAvailability()
+        if (!available) {
+            this.#onError?.(reason)
+            return
+        }
+
+        const canvas = this.#getCanvas()
+
+        this.#stream = canvas.captureStream(fps)
+        this.#pc = new RTCPeerConnection()
+
+        this.#stream.getTracks().forEach((t) => this.#pc.addTrack(t, this.#stream))
+
+        this.#pc.onicecandidate = (e) => {
+            if (e.candidate) {
+                this.#onIceCandidate?.(e.candidate.toJSON())
+            }
+        }
+
+        const offer = await this.#pc.createOffer()
+        await this.#pc.setLocalDescription(offer)
+        this.#onOffer?.(offer.sdp)
+        this.#onStarted?.()
+    }
+
+    async handleAnswer({ sdp }) {
+        if (this.#pc) {
+            await this.#pc.setRemoteDescription(
+                new RTCSessionDescription({ type: 'answer', sdp }),
+            )
+        }
+    }
+
+    async handleIce(candidate) {
+        if (this.#pc && candidate) {
+            await this.#pc.addIceCandidate(new RTCIceCandidate(candidate))
+        }
+    }
+
+    takeScreenshot({ type = 'image/png', quality = 0.92 } = {}) {
+        const canvas = this.#getCanvas()
+        if (!canvas) {
+            return { success: false, reason: 'Canvas not found', data: null }
+        }
+        const data = canvas.toDataURL(type, quality)
+        return { success: true, reason: null, data }
+    }
+
+    stopCapture() {
+        this.#stream?.getTracks().forEach((t) => t.stop())
+        this.#pc?.close()
+        this.#pc = null
+        this.#stream = null
+    }
+
+    #getCanvas() {
+        return document.querySelector('canvas')
+    }
+
+    #isWebRTCSupported() {
+        return typeof RTCPeerConnection !== 'undefined'
+    }
+
+    #isCaptureStreamSupported() {
+        return typeof HTMLCanvasElement.prototype.captureStream === 'function'
+    }
+}
+
+export { RecorderModule }
+export default new RecorderModule()

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -68,6 +68,7 @@ class RecorderModule {
      * @param {'very-low'|'low'|'medium'|'high'} [options.priority] - Encoding priority
      * @param {'very-low'|'low'|'medium'|'high'} [options.networkPriority] - Network-level priority
      * @param {string} [options.scalabilityMode] - SVC scalability mode (e.g. "L1T3")
+     * @param {string} [options.contentHint='detail'] - Track content hint ('detail', 'motion', 'text')
      */
     async startCapture(options = {}) {
         const { available, reason } = this.checkAvailability()
@@ -79,6 +80,12 @@ class RecorderModule {
         const canvas = this.#getCanvas()
 
         this.#stream = canvas.captureStream(options.fps || 30)
+
+        if (options.contentHint) {
+            const track = this.#stream.getVideoTracks()[0]
+            if (track) track.contentHint = options.contentHint
+        }
+
         this.#pc = new RTCPeerConnection()
 
         this.#stream.getTracks().forEach((t) => this.#pc.addTrack(t, this.#stream))
@@ -92,18 +99,7 @@ class RecorderModule {
         const offer = await this.#pc.createOffer()
         await this.#pc.setLocalDescription(offer)
 
-        const hasEncodingParams = [
-            options.maxBitrate,
-            options.minBitrate,
-            options.maxFramerate,
-            options.scaleResolutionDownBy,
-            options.priority,
-            options.networkPriority,
-            options.scalabilityMode,
-        ].some((v) => v !== undefined)
-        if (hasEncodingParams) {
-            this.#applyEncodingParams(options)
-        }
+        this.#applyEncodingParams(options)
 
         this.#onOffer?.(offer.sdp)
         this.#onStarted?.()

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -18,6 +18,8 @@
 import PlatformBridgeBase from './PlatformBridgeBase'
 import MessageBroker from '../common/MessageBroker'
 import configFileModule from '../modules/ConfigFileModule'
+import recorderModule from '../modules/RecorderModule'
+
 import {
     PLATFORM_ID,
     MODULE_NAME,
@@ -73,6 +75,18 @@ export const ACTION_NAME_QA = {
     CLEAN_CACHE: 'clean_cache',
     SHOW_ADVANCED_BANNERS: 'show_advanced_banners',
     HIDE_ADVANCED_BANNERS: 'hide_advanced_banners',
+}
+
+const RECORDER_ACTION = {
+    START_CAPTURE: 'start_capture',
+    STOP_CAPTURE: 'stop_capture',
+    RTC_OFFER: 'rtc_offer',
+    RTC_ANSWER: 'rtc_answer',
+    RTC_ICE: 'rtc_ice',
+    CAPTURE_STARTED: 'capture_started',
+    CAPTURE_ERROR: 'capture_error',
+    TAKE_SCREENSHOT: 'take_screenshot',
+    SCREENSHOT_RESULT: 'screenshot_result',
 }
 
 const INTERSTITIAL_STATUS = {
@@ -292,10 +306,15 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                     }
                 } else if (data.type === MODULE_NAME.ADVERTISEMENT) {
                     this.#handleAdvertisement(data)
+                } else if (data.type === MODULE_NAME.RECORDER) {
+                    this.#handleRecorder(data)
                 }
             }
 
             this.#messageBroker.addListener(messageHandler)
+
+            this.#initRecorderCallbacks()
+
             this.#sendMessage({
                 type: MODULE_NAME.PLATFORM,
                 action: ACTION_NAME.INITIALIZE,
@@ -1238,6 +1257,64 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 default:
                     break
             }
+        }
+    }
+
+    #handleRecorder(data) {
+        switch (data.action) {
+            case RECORDER_ACTION.START_CAPTURE:
+                recorderModule.startCapture(data.options || {})
+                break
+            case RECORDER_ACTION.STOP_CAPTURE:
+                recorderModule.stopCapture()
+                break
+            case RECORDER_ACTION.RTC_ANSWER:
+                recorderModule.handleAnswer(data.options)
+                break
+            case RECORDER_ACTION.RTC_ICE:
+                recorderModule.handleIce(data.options)
+                break
+            case RECORDER_ACTION.TAKE_SCREENSHOT: {
+                const result = recorderModule.takeScreenshot(data.options || {})
+                this.#sendMessage({
+                    type: MODULE_NAME.RECORDER,
+                    action: RECORDER_ACTION.SCREENSHOT_RESULT,
+                    payload: result,
+                })
+                break
+            }
+            default:
+                break
+        }
+    }
+
+    #initRecorderCallbacks() {
+        recorderModule.onOffer = (sdp) => {
+            this.#sendMessage({
+                type: MODULE_NAME.RECORDER,
+                action: RECORDER_ACTION.RTC_OFFER,
+                payload: { sdp },
+            })
+        }
+        recorderModule.onIceCandidate = (candidate) => {
+            this.#sendMessage({
+                type: MODULE_NAME.RECORDER,
+                action: RECORDER_ACTION.RTC_ICE,
+                payload: candidate,
+            })
+        }
+        recorderModule.onStarted = () => {
+            this.#sendMessage({
+                type: MODULE_NAME.RECORDER,
+                action: RECORDER_ACTION.CAPTURE_STARTED,
+            })
+        }
+        recorderModule.onError = (message) => {
+            this.#sendMessage({
+                type: MODULE_NAME.RECORDER,
+                action: RECORDER_ACTION.CAPTURE_ERROR,
+                payload: { message },
+            })
         }
     }
 

--- a/tests/common/playgama/playgama.ts
+++ b/tests/common/playgama/playgama.ts
@@ -42,10 +42,17 @@ export function createPlaygamaSdk(
     }
 
 
+    const platformService = {
+        isReady: Promise.resolve(),
+        getIsPaymentsSupported: vi.fn().mockReturnValue(false),
+        getAdditionalParams: vi.fn().mockReturnValue({}),
+    }
+
     testGlobalThis.PLAYGAMA_SDK = {
         userService,
         advService,
         cloudSaveApi,
+        platformService,
     }
 
     return Promise.resolve()

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -1,0 +1,314 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+import { RecorderModule } from '../../../src/modules/RecorderModule'
+
+function createRecorderModule() {
+    return new RecorderModule()
+}
+
+function createMockCanvas(options: { toDataURL?: string } = {}) {
+    const canvas = document.createElement('canvas')
+    vi.spyOn(canvas, 'toDataURL').mockReturnValue(options.toDataURL || 'data:image/png;base64,mockData')
+    canvas.captureStream = vi.fn().mockReturnValue({
+        getTracks: () => [{ stop: vi.fn() }],
+    })
+    document.body.appendChild(canvas)
+    return canvas
+}
+
+function createMockRTCPeerConnection() {
+    const mockPc = {
+        addTrack: vi.fn(),
+        createOffer: vi.fn().mockResolvedValue({ sdp: 'mock-offer-sdp', type: 'offer' }),
+        setLocalDescription: vi.fn().mockResolvedValue(undefined),
+        setRemoteDescription: vi.fn().mockResolvedValue(undefined),
+        addIceCandidate: vi.fn().mockResolvedValue(undefined),
+        close: vi.fn(),
+        onicecandidate: null as ((e: { candidate: unknown }) => void) | null,
+    }
+
+    global.RTCPeerConnection = vi.fn().mockImplementation(() => mockPc) as unknown as typeof RTCPeerConnection
+    return mockPc
+}
+
+describe('RecorderModule', () => {
+    let canvas: HTMLCanvasElement | null = null
+
+    beforeEach(() => {
+        vi.restoreAllMocks()
+        HTMLCanvasElement.prototype.captureStream = vi.fn()
+        global.RTCSessionDescription = vi.fn().mockImplementation((desc) => desc) as unknown as typeof RTCSessionDescription
+        global.RTCIceCandidate = vi.fn().mockImplementation((c) => c) as unknown as typeof RTCIceCandidate
+    })
+
+    afterEach(() => {
+        if (canvas) {
+            canvas.remove()
+            canvas = null
+        }
+        // @ts-expect-error cleanup
+        delete global.RTCPeerConnection
+        // @ts-expect-error cleanup
+        delete global.RTCSessionDescription
+        // @ts-expect-error cleanup
+        delete global.RTCIceCandidate
+    })
+
+    describe('checkAvailability', () => {
+        test('should return unavailable when RTCPeerConnection is not defined', () => {
+            canvas = createMockCanvas()
+            // RTCPeerConnection not defined (deleted in afterEach)
+
+            const module = createRecorderModule()
+            const result = module.checkAvailability()
+
+            expect(result).toEqual({ available: false, reason: 'RTCPeerConnection is not supported' })
+        })
+
+        test('should return unavailable when captureStream is not supported', () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+            // @ts-expect-error remove captureStream
+            delete HTMLCanvasElement.prototype.captureStream
+
+            const module = createRecorderModule()
+            const result = module.checkAvailability()
+
+            expect(result).toEqual({ available: false, reason: 'captureStream is not supported' })
+        })
+
+        test('should return unavailable when canvas is not found', () => {
+            createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            const result = module.checkAvailability()
+
+            expect(result).toEqual({ available: false, reason: 'Canvas not found' })
+        })
+
+        test('should return available when all conditions are met', () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            const result = module.checkAvailability()
+
+            expect(result).toEqual({ available: true, reason: null })
+        })
+    })
+
+    describe('startCapture', () => {
+        test('should call onError when not available', async () => {
+            createMockRTCPeerConnection()
+            const onError = vi.fn()
+
+            const module = createRecorderModule()
+            module.onError = onError
+            await module.startCapture()
+
+            expect(onError).toHaveBeenCalledWith('Canvas not found')
+        })
+
+        test('should create peer connection and generate offer', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const onOffer = vi.fn()
+            const onStarted = vi.fn()
+
+            const module = createRecorderModule()
+            module.onOffer = onOffer
+            module.onStarted = onStarted
+            await module.startCapture()
+
+            expect(mockPc.createOffer).toHaveBeenCalled()
+            expect(mockPc.setLocalDescription).toHaveBeenCalled()
+            expect(onOffer).toHaveBeenCalledWith('mock-offer-sdp')
+            expect(onStarted).toHaveBeenCalled()
+        })
+
+        test('should use custom fps', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            await module.startCapture({ fps: 60 })
+
+            expect(canvas.captureStream).toHaveBeenCalledWith(60)
+        })
+
+        test('should use default fps of 30', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            await module.startCapture()
+
+            expect(canvas.captureStream).toHaveBeenCalledWith(30)
+        })
+
+        test('should forward ice candidates', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const onIceCandidate = vi.fn()
+            const mockCandidate = { candidate: 'mock-candidate', sdpMid: '0', sdpMLineIndex: 0 }
+
+            const module = createRecorderModule()
+            module.onIceCandidate = onIceCandidate
+            await module.startCapture()
+
+            mockPc.onicecandidate?.({
+                candidate: { toJSON: () => mockCandidate },
+            })
+
+            expect(onIceCandidate).toHaveBeenCalledWith(mockCandidate)
+        })
+
+        test('should not forward null ice candidates', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const onIceCandidate = vi.fn()
+
+            const module = createRecorderModule()
+            module.onIceCandidate = onIceCandidate
+            await module.startCapture()
+
+            mockPc.onicecandidate?.({ candidate: null })
+
+            expect(onIceCandidate).not.toHaveBeenCalled()
+        })
+
+        test('should not throw when callbacks are not set', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            await expect(module.startCapture()).resolves.toBeUndefined()
+        })
+    })
+
+    describe('handleAnswer', () => {
+        test('should set remote description after startCapture', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            await module.startCapture()
+            await module.handleAnswer({ sdp: 'mock-answer-sdp' })
+
+            expect(mockPc.setRemoteDescription).toHaveBeenCalledWith(
+                expect.objectContaining({ type: 'answer', sdp: 'mock-answer-sdp' }),
+            )
+        })
+
+        test('should do nothing when peer connection does not exist', async () => {
+            const module = createRecorderModule()
+            await expect(module.handleAnswer({ sdp: 'mock-answer-sdp' })).resolves.toBeUndefined()
+        })
+    })
+
+    describe('handleIce', () => {
+        test('should add ice candidate after startCapture', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+
+            const candidate = { candidate: 'mock', sdpMid: '0', sdpMLineIndex: 0 }
+            const module = createRecorderModule()
+            await module.startCapture()
+            await module.handleIce(candidate)
+
+            expect(mockPc.addIceCandidate).toHaveBeenCalled()
+        })
+
+        test('should do nothing when peer connection does not exist', async () => {
+            const module = createRecorderModule()
+            await expect(module.handleIce({ candidate: 'mock' })).resolves.toBeUndefined()
+        })
+
+        test('should do nothing when candidate is null', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            await module.startCapture()
+            await module.handleIce(null)
+
+            expect(mockPc.addIceCandidate).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('takeScreenshot', () => {
+        test('should return error when canvas is not found', () => {
+            const module = createRecorderModule()
+            const result = module.takeScreenshot()
+
+            expect(result).toEqual({ success: false, reason: 'Canvas not found', data: null })
+        })
+
+        test('should return base64 data from canvas', () => {
+            canvas = createMockCanvas({ toDataURL: 'data:image/png;base64,screenshotData' })
+
+            const module = createRecorderModule()
+            const result = module.takeScreenshot()
+
+            expect(result).toEqual({
+                success: true,
+                reason: null,
+                data: 'data:image/png;base64,screenshotData',
+            })
+        })
+
+        test('should use default type and quality', () => {
+            canvas = createMockCanvas()
+
+            const module = createRecorderModule()
+            module.takeScreenshot()
+
+            expect(canvas.toDataURL).toHaveBeenCalledWith('image/png', 0.92)
+        })
+
+        test('should use custom type and quality', () => {
+            canvas = createMockCanvas()
+
+            const module = createRecorderModule()
+            module.takeScreenshot({ type: 'image/jpeg', quality: 0.5 })
+
+            expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.5)
+        })
+    })
+
+    describe('stopCapture', () => {
+        test('should stop tracks and close peer connection', async () => {
+            const stopFn = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop: stopFn }],
+            })
+            const mockPc = createMockRTCPeerConnection()
+
+            const module = createRecorderModule()
+            await module.startCapture()
+            module.stopCapture()
+
+            expect(stopFn).toHaveBeenCalled()
+            expect(mockPc.close).toHaveBeenCalled()
+        })
+
+        test('should not throw when called without startCapture', () => {
+            const module = createRecorderModule()
+            expect(() => module.stopCapture()).not.toThrow()
+        })
+
+        test('should allow startCapture again after stopCapture', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+            const onStarted = vi.fn()
+
+            const module = createRecorderModule()
+            module.onStarted = onStarted
+            await module.startCapture()
+            module.stopCapture()
+            await module.startCapture()
+
+            expect(onStarted).toHaveBeenCalledTimes(2)
+        })
+    })
+})

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -16,12 +16,19 @@ function createMockCanvas(options: { toDataURL?: string } = {}) {
 }
 
 function createMockRTCPeerConnection() {
+    const setParameters = vi.fn().mockResolvedValue(undefined)
+    const mockSender = {
+        track: { kind: 'video' },
+        getParameters: vi.fn().mockReturnValue({ encodings: [{}] }),
+        setParameters,
+    }
     const mockPc = {
         addTrack: vi.fn(),
         createOffer: vi.fn().mockResolvedValue({ sdp: 'mock-offer-sdp', type: 'offer' }),
         setLocalDescription: vi.fn().mockResolvedValue(undefined),
         setRemoteDescription: vi.fn().mockResolvedValue(undefined),
         addIceCandidate: vi.fn().mockResolvedValue(undefined),
+        getSenders: vi.fn().mockReturnValue([mockSender]),
         close: vi.fn(),
         onicecandidate: null as ((e: { candidate: unknown }) => void) | null,
     }
@@ -143,6 +150,63 @@ describe('RecorderModule', () => {
             await module.startCapture()
 
             expect(canvas.captureStream).toHaveBeenCalledWith(30)
+        })
+
+        test('should apply maxBitrate to video sender', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const sender = mockPc.getSenders()[0]
+
+            const module = createRecorderModule()
+            await module.startCapture({ maxBitrate: 5000000 })
+
+            expect(sender.getParameters).toHaveBeenCalled()
+            expect(sender.setParameters).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    encodings: [{ maxBitrate: 5000000 }],
+                }),
+            )
+        })
+
+        test('should apply minBitrate to video sender', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const sender = mockPc.getSenders()[0]
+
+            const module = createRecorderModule()
+            await module.startCapture({ minBitrate: 1000000 })
+
+            expect(sender.setParameters).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    encodings: [{ minBitrate: 1000000 }],
+                }),
+            )
+        })
+
+        test('should apply both maxBitrate and minBitrate', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const sender = mockPc.getSenders()[0]
+
+            const module = createRecorderModule()
+            await module.startCapture({ maxBitrate: 5000000, minBitrate: 1000000 })
+
+            expect(sender.setParameters).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    encodings: [{ maxBitrate: 5000000, minBitrate: 1000000 }],
+                }),
+            )
+        })
+
+        test('should not apply bitrate constraints when not specified', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            const sender = mockPc.getSenders()[0]
+
+            const module = createRecorderModule()
+            await module.startCapture()
+
+            expect(sender.setParameters).not.toHaveBeenCalled()
         })
 
         test('should forward ice candidates', async () => {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,10 +1,19 @@
 import { defineConfig } from 'vitest/config'
+import fs from 'fs'
+
+const source = fs.readFileSync('./src/platformImports.js', 'utf-8')
+const platformDefines = {}
+const regex = /__INCLUDE_(\w+)__/g
+let match
+while ((match = regex.exec(source)) !== null) {
+    platformDefines[`__INCLUDE_${match[1]}__`] = true
+}
 
 export default defineConfig({
+    define: platformDefines,
     test: {
         environment: 'jsdom',
         include: ['tests/**/*.spec.ts'],
         globals: true,
     },
 })
-


### PR DESCRIPTION
## What's Done

- Added `RECORDER` to `MODULE_NAME` constants to register the new module
- Implemented `RecorderModule` with:
  - WebRTC-based canvas capture via `RTCPeerConnection` and `captureStream`
  - Screenshot support using `canvas.toDataURL`
  - Availability checks for WebRTC, `captureStream`, and canvas presence
- Integrated `RecorderModule` into `QaToolPlatformBridge`:
  - Message protocol handling for recorder actions
  - Callbacks for start/stop recording and screenshot requests
- Added 23 unit tests covering all module functionality

## Changed Files

- `src/constants.js` — added `RECORDER` to `MODULE_NAME` enum
- `src/modules/RecorderModule.js` — new module implementing WebRTC canvas capture and screenshots
- `src/platform-bridges/QaToolPlatformBridge.js` — recorder integration with message handling and callbacks
- `tests/src/modules/recorderModule.spec.ts` — 23 unit tests for `RecorderModule`