### PR TITLE
QaTool: Add config override handler and fix payment product mapping

### DIFF
--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -1043,28 +1043,15 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
             return []
         }
 
-        return this._options.payments
-            .map((product) => ({
-                id: product.id,
-                ...product.playgama,
-            }))
+        return this._options.payments.map((product) => ({
+            id: product.id,
+            ...product[PLATFORM_ID.PLAYGAMA],
+            ...product[PLATFORM_ID.QA_TOOL],
+        }))
     }
 
     _paymentsGetProductPlatformData(id) {
-        const products = this._options.payments
-        if (!products) {
-            return null
-        }
-
-        const product = products.find((p) => p.id === id)
-        if (!product) {
-            return null
-        }
-
-        return {
-            id: product.id,
-            ...product.playgama,
-        }
+        return this._paymentsGetProductsPlatformData().find((p) => p.id === id) ?? null
     }
 
     #handleInitializeResponse(data) {

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -75,6 +75,7 @@ export const ACTION_NAME_QA = {
     CLEAN_CACHE: 'clean_cache',
     SHOW_ADVANCED_BANNERS: 'show_advanced_banners',
     HIDE_ADVANCED_BANNERS: 'hide_advanced_banners',
+    CONFIG_OVERRIDE: 'config_override',
 }
 
 const RECORDER_ACTION = {
@@ -303,6 +304,8 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                         this.#getPerformanceResources(messageId, requestedProps)
                     } else if (data.action === ACTION_NAME_QA.CLEAN_CACHE) {
                         this.#cleanCache()
+                    } else if (data.action === ACTION_NAME_QA.CONFIG_OVERRIDE) {
+                        this.#handleConfigOverride(data)
                     }
                 } else if (data.type === MODULE_NAME.ADVERTISEMENT) {
                     this.#handleAdvertisement(data)
@@ -1099,6 +1102,15 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
 
     #handlePauseState(data) {
         this._setPauseState(data.options.isPaused)
+    }
+
+    #handleConfigOverride(data) {
+        const newOptions = data?.options
+        if (!newOptions || typeof newOptions !== 'object') {
+            return
+        }
+
+        this._options = { ...this._options, ...newOptions }
     }
 
     #getPerformanceResources(messageId, requestedProps = []) {


### PR DESCRIPTION
## What was done

- Added a `CONFIG_OVERRIDE` action handler in `QaToolPlatformBridge`. The bridge now accepts a `{ type: 'platform', action: 'config_override', options: {...} }` postMessage at runtime and merges the incoming options into `this._options` via a shallow top-level merge. No acknowledgement is sent back; `configFileModule` is not modified. Because modules read options through the `bridge.options` getter without caching, the override propagates immediately.

- In `_paymentsGetProductsPlatformData` and `_paymentsGetProductPlatformData`: replaced hardcoded string literals `'playgama'` and `'qa_tool'` with `PLATFORM_ID.PLAYGAMA` / `PLATFORM_ID.QA_TOOL` constants. Added `product[PLATFORM_ID.QA_TOOL]` spread on top of `product[PLATFORM_ID.PLAYGAMA]` so that qa_tool-specific fields take priority over the playgama base config. Reduced `_paymentsGetProductPlatformData` to a one-liner that reuses the result of `_paymentsGetProductsPlatformData()`, removing duplicate merge logic.

## Changed files

- `src/platform-bridges/QaToolPlatformBridge.js` — config override handler, payment product mapping deduplication and qa_tool override priority