### PR TITLE
QaTool: Add config override handler and dedupe payment product mapping

### DIFF
--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -82,6 +82,7 @@ export const ACTION_NAME_QA = {
     CLEAN_CACHE: 'clean_cache',
     SHOW_ADVANCED_BANNERS: 'show_advanced_banners',
     HIDE_ADVANCED_BANNERS: 'hide_advanced_banners',
+    CONFIG_OVERRIDE: 'config_override',
 } as const
 export type ActionNameQa = typeof ACTION_NAME_QA[keyof typeof ACTION_NAME_QA]
 
@@ -354,6 +355,8 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                         this.#getPerformanceResources(messageId, requestedProps)
                     } else if (data.action === ACTION_NAME_QA.CLEAN_CACHE) {
                         this.#cleanCache()
+                    } else if (data.action === ACTION_NAME_QA.CONFIG_OVERRIDE) {
+                        this.#handleConfigOverride(data)
                     }
                 } else if (data.type === MODULE_NAME.ADVERTISEMENT) {
                     this.#handleAdvertisement(data)
@@ -1126,6 +1129,15 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
 
     #handlePauseState(data: QaToolMessage): void {
         this._setPauseState((data.options as { isPaused: boolean }).isPaused)
+    }
+
+    #handleConfigOverride(data: QaToolMessage): void {
+        const newOptions = data?.options
+        if (!newOptions || typeof newOptions !== 'object') {
+            return
+        }
+
+        this._options = { ...this._options, ...newOptions }
     }
 
     #getPerformanceResources(messageId: string, requestedProps: string[] = []): Promise<PerformanceEntry[]> {

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -1069,28 +1069,15 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
             return []
         }
 
-        return this._options.payments
-            .map((product) => ({
-                id: product.id,
-                ...(product.playgama as AnyRecord | undefined),
-            }))
+        return this._options.payments.map((product) => ({
+            id: product.id,
+            ...(product[PLATFORM_ID.PLAYGAMA] as AnyRecord | undefined),
+            ...(product[PLATFORM_ID.QA_TOOL] as AnyRecord | undefined),
+        }))
     }
 
     protected _paymentsGetProductPlatformData(id: string): AnyRecord | null {
-        const products = this._options.payments
-        if (!products) {
-            return null
-        }
-
-        const product = products.find((p) => p.id === id)
-        if (!product) {
-            return null
-        }
-
-        return {
-            id: product.id,
-            ...(product.playgama as AnyRecord | undefined),
-        }
+        return this._paymentsGetProductsPlatformData().find((p) => p.id === id) ?? null
     }
 
     #handleInitializeResponse(data: QaToolMessage): void {


### PR DESCRIPTION
## What was done

- Added a `CONFIG_OVERRIDE` action handler to `QaToolPlatformBridge`. When the QA tool sends a `{ type: 'platform', action: 'config_override', options: {...} }` message at runtime, the bridge performs a shallow top-level merge of the incoming options into `this._options`. No acknowledgement is sent back; `configFileModule` is not modified. Since modules read options through the `bridge.options` getter without caching, the change propagates immediately.

- In `_paymentsGetProductsPlatformData` and `_paymentsGetProductPlatformData`:
  - Replaced hardcoded string keys `'playgama'` with `PLATFORM_ID.PLAYGAMA` / `PLATFORM_ID.QA_TOOL` constants.
  - Added `product[PLATFORM_ID.QA_TOOL]` spread on top of `product[PLATFORM_ID.PLAYGAMA]` so qa_tool-specific fields override the playgama base config.
  - Reduced `_paymentsGetProductPlatformData` to a one-liner that searches within the result of `_paymentsGetProductsPlatformData()`, eliminating duplicate merge logic.

## Changed files

- `src/platform-bridges/QaToolPlatformBridge.ts` — config override handler, payment product mapping deduplication, and constant-based platform ID keys.

## Notes

Mirrors #192 for the TypeScript line.