### PR TITLE
QA tool payments to use catalog data from QA tool platform

### DIFF
--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -849,10 +849,7 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
             promiseDecorator = this._createPromiseDecorator(ACTION_NAME.GET_PURCHASES)
 
             this.#requestMessage(MODULE_NAME.PAYMENTS, ACTION_NAME.GET_PURCHASES).then(({ purchases }) => {
-                // const products = this._paymentsGetProductsPlatformData()
-
                 this._paymentsPurchases = purchases.map((purchase) => purchase.purchaseData)
-
                 this._resolvePromiseDecorator(ACTION_NAME.GET_PURCHASES, this._paymentsPurchases)
             })
         }

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -745,22 +745,12 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
             return Promise.reject()
         }
 
-        const product = this._paymentsGetProductPlatformData(id)
-        if (!product) {
-            return Promise.reject()
-        }
-
-        if (options && options.externalId) {
-            product.externalId = options.externalId
-        }
-
-        if (!product.externalId) {
-            product.externalId = this._paymentsGenerateTransactionId(id)
-        }
-
         let promiseDecorator = this._getPromiseDecorator(ACTION_NAME.PURCHASE)
         if (!promiseDecorator) {
             promiseDecorator = this._createPromiseDecorator(ACTION_NAME.PURCHASE)
+
+            const externalId = options?.externalId || this._paymentsGenerateTransactionId(id)
+            const product = { id, externalId }
 
             this.#requestMessage(MODULE_NAME.PAYMENTS, ACTION_NAME.PURCHASE, {
                 options: { product },
@@ -833,17 +823,13 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
         if (!promiseDecorator) {
             promiseDecorator = this._createPromiseDecorator(ACTION_NAME.GET_CATALOG)
 
-            const products = this._paymentsGetProductsPlatformData()
-
-            this.#requestMessage(MODULE_NAME.PAYMENTS, ACTION_NAME.GET_CATALOG, {
-                options: { products },
-            }).then(() => {
-                const mergedProducts = products.map((product) => ({
+            this.#requestMessage(MODULE_NAME.PAYMENTS, ACTION_NAME.GET_CATALOG).then(({ payload }) => {
+                const mergedProducts = payload.products.map((product) => ({
                     id: product.id,
-                    price: `${product.amount} Gam`,
-                    priceCurrencyCode: 'Gam',
-                    priceCurrencyImage: 'https://games.playgama.com/assets/gold-fennec-coin-large.webp',
-                    priceValue: product.amount,
+                    price: `${product.price} ${product.currency}`,
+                    priceCurrencyCode: product.currency,
+                    priceCurrencyImage: product.priceCurrencyImage,
+                    priceValue: product.price,
                 }))
 
                 this._resolvePromiseDecorator(ACTION_NAME.GET_CATALOG, mergedProducts)
@@ -862,18 +848,10 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
         if (!promiseDecorator) {
             promiseDecorator = this._createPromiseDecorator(ACTION_NAME.GET_PURCHASES)
 
-            this.#requestMessage(MODULE_NAME.PAYMENTS, ACTION_NAME.GET_PURCHASES, {
-                options: { products: this._paymentsGetProductsPlatformData() },
-            }).then(({ purchases }) => {
-                const products = this._paymentsGetProductsPlatformData()
+            this.#requestMessage(MODULE_NAME.PAYMENTS, ACTION_NAME.GET_PURCHASES).then(({ purchases }) => {
+                // const products = this._paymentsGetProductsPlatformData()
 
-                this._paymentsPurchases = purchases.map((purchase) => {
-                    const product = products.find((p) => p.id === purchase.id)
-                    return {
-                        id: product.id,
-                        ...purchase.purchaseData,
-                    }
-                })
+                this._paymentsPurchases = purchases.map((purchase) => purchase.purchaseData)
 
                 this._resolvePromiseDecorator(ACTION_NAME.GET_PURCHASES, this._paymentsPurchases)
             })
@@ -1033,35 +1011,6 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
         })
 
         return Promise.resolve()
-    }
-
-    _paymentsGetProductsPlatformData() {
-        if (!this._options.payments) {
-            return []
-        }
-
-        return this._options.payments
-            .map((product) => ({
-                id: product.id,
-                ...product.playgama,
-            }))
-    }
-
-    _paymentsGetProductPlatformData(id) {
-        const products = this._options.payments
-        if (!products) {
-            return null
-        }
-
-        const product = products.find((p) => p.id === id)
-        if (!product) {
-            return null
-        }
-
-        return {
-            id: product.id,
-            ...product.playgama,
-        }
     }
 
     #handleInitializeResponse(data) {


### PR DESCRIPTION
## Summary
Simplifies the QA tool payments flow so it relies on data coming from the QA tool messages instead of locally-stored product platform data.

- **Purchase**: build the purchase payload directly from `id` and `externalId` (`options.externalId` or a generated transaction id) instead of looking up local product platform data.
- **Get catalog**: stop sending products in the request; read `price`, `currency` and `priceCurrencyImage` from the `GET_CATALOG` response payload instead of the hardcoded `Gam` values.
- **Get purchases**: stop sending products and map purchases straight from `purchaseData`.
- Remove the now-unused `_paymentsGetProductsPlatformData` / `_paymentsGetProductPlatformData` helpers.