### PR TITLE
Add CI workflow to publish bridge builds to S3

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -4,24 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       channel:
-        description: Where to publish
+        description: Target channel (S3 folder v<major>/<channel>/)
         type: choice
         default: stable
         options:
           - stable
           - latest
-      scope:
-        description: What to build & publish
-        type: choice
-        default: all
-        options:
-          - all
-          - base
-          - platforms
-      platform:
-        description: Single platform id (optional, only with scope=platforms/all)
-        type: string
-        required: false
+          - dev
 
 jobs:
   publish:
@@ -29,8 +18,6 @@ jobs:
     with:
       environment: production
       channel: ${{ inputs.channel }}
-      scope: ${{ inputs.scope }}
-      platform: ${{ inputs.platform }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,37 @@
+name: Release to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Where to publish
+        type: choice
+        default: stable
+        options:
+          - stable
+          - latest
+      scope:
+        description: What to build & publish
+        type: choice
+        default: all
+        options:
+          - all
+          - base
+          - platforms
+      platform:
+        description: Single platform id (optional, only with scope=platforms/all)
+        type: string
+        required: false
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      environment: production
+      channel: ${{ inputs.channel }}
+      scope: ${{ inputs.scope }}
+      platform: ${{ inputs.platform }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET_PRODUCTION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,18 +11,9 @@ on:
         type: string
         required: true
       channel:
-        description: stable (v<major>/stable) | latest (root latest)
+        description: stable | latest | dev (S3 folder v<major>/<channel>/)
         type: string
         required: true
-      scope:
-        description: all | base | platforms
-        type: string
-        required: true
-      platform:
-        description: single platform id (optional)
-        type: string
-        required: false
-        default: ''
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -63,12 +54,16 @@ jobs:
           cache: npm
       - run: npm ci
       - name: Build artifacts
+        env:
+          BUCKET: ${{ secrets.S3_BUCKET }}
         run: |
-          PLATFORM_ARG=""
-          if [ -n "${{ inputs.platform }}" ]; then
-            PLATFORM_ARG="--platform=${{ inputs.platform }}"
+          if [ -z "${BUCKET}" ]; then
+            echo "::error::S3_BUCKET secret is empty."
+            exit 1
           fi
-          node scripts/build-dist.js --scope=${{ inputs.scope }} $PLATFORM_ARG
+          MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+          PUBLIC_PATH="https://${BUCKET}/v${MAJOR}/${{ inputs.channel }}/"
+          node scripts/build-dist.js --type=both --public-path="$PUBLIC_PATH"
       - uses: actions/upload-artifact@v4
         with:
           name: dist-publish
@@ -98,13 +93,8 @@ jobs:
             echo "::error::S3_BUCKET secret is empty."
             exit 1
           fi
-          if [ "${{ inputs.channel }}" = "latest" ]; then
-            # Root rolling alias, not version-scoped.
-            DEST="latest"
-          else
-            MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
-            DEST="v${MAJOR}/stable"
-          fi
+          MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+          DEST="v${MAJOR}/${{ inputs.channel }}"
           echo "Publishing ${{ inputs.environment }}/${{ inputs.channel }} -> s3://***/${DEST}/"
           aws s3 cp dist/publish/ "s3://${BUCKET}/${DEST}/" \
             --recursive \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,113 @@
+name: Publish (reusable)
+
+# Reusable workflow: verify -> build -> upload to an S3 bucket.
+# Not triggered directly. Called by staging.yml / production.yml.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: staging | production (drives the main-branch guard)
+        type: string
+        required: true
+      channel:
+        description: stable (v<major>/stable) | latest (root latest)
+        type: string
+        required: true
+      scope:
+        description: all | base | platforms
+        type: string
+        required: true
+      platform:
+        description: single platform id (optional)
+        type: string
+        required: false
+        default: ''
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      S3_BUCKET:
+        required: true
+
+env:
+  AWS_REGION: eu-central-1
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard production to main branch
+        if: ${{ inputs.environment == 'production' && github.ref_name != 'main' }}
+        run: |
+          echo "::error::production is only allowed from the 'main' branch (got '${{ github.ref_name }}')."
+          exit 1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Build artifacts
+        run: |
+          PLATFORM_ARG=""
+          if [ -n "${{ inputs.platform }}" ]; then
+            PLATFORM_ARG="--platform=${{ inputs.platform }}"
+          fi
+          node scripts/build-dist.js --scope=${{ inputs.scope }} $PLATFORM_ARG
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-publish
+          path: dist/publish/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-publish
+          path: dist/publish
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Upload to S3
+        env:
+          BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          if [ -z "${BUCKET}" ]; then
+            echo "::error::S3_BUCKET secret is empty."
+            exit 1
+          fi
+          if [ "${{ inputs.channel }}" = "latest" ]; then
+            # Root rolling alias, not version-scoped.
+            DEST="latest"
+          else
+            MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+            DEST="v${MAJOR}/stable"
+          fi
+          echo "Publishing ${{ inputs.environment }}/${{ inputs.channel }} -> s3://***/${DEST}/"
+          aws s3 cp dist/publish/ "s3://${BUCKET}/${DEST}/" \
+            --recursive \
+            --content-type application/javascript \
+            --no-progress
+      # CDN cache purge is intentionally omitted for now.

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,36 +1,27 @@
 name: Release to Staging
 
 on:
+  # TEMP: verify this branch by auto-deploying to the dev channel on push. Remove before merge.
+  push:
+    branches: [ci-cd]
   workflow_dispatch:
     inputs:
       channel:
-        description: Where to publish
+        description: Target channel (S3 folder v<major>/<channel>/)
         type: choice
-        default: stable
+        default: dev
         options:
+          - dev
           - stable
           - latest
-      scope:
-        description: What to build & publish
-        type: choice
-        default: all
-        options:
-          - all
-          - base
-          - platforms
-      platform:
-        description: Single platform id (optional, only with scope=platforms/all)
-        type: string
-        required: false
 
 jobs:
   publish:
     uses: ./.github/workflows/publish.yml
     with:
       environment: staging
-      channel: ${{ inputs.channel }}
-      scope: ${{ inputs.scope }}
-      platform: ${{ inputs.platform }}
+      # Falls back to 'dev' on push (workflow_dispatch inputs are empty then).
+      channel: ${{ inputs.channel || 'dev' }}
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,37 @@
+name: Release to Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Where to publish
+        type: choice
+        default: stable
+        options:
+          - stable
+          - latest
+      scope:
+        description: What to build & publish
+        type: choice
+        default: all
+        options:
+          - all
+          - base
+          - platforms
+      platform:
+        description: Single platform id (optional, only with scope=platforms/all)
+        type: string
+        required: false
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      environment: staging
+      channel: ${{ inputs.channel }}
+      scope: ${{ inputs.scope }}
+      platform: ${{ inputs.platform }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "build:bundled": "webpack --config-name bundled",
         "build:nolint": "webpack --config-name bundled --env noLint",
         "build:platform": "node scripts/build-platform.js",
+        "build:dist": "node scripts/build-dist.js",
         "develop": "webpack --mode=development",
         "dev": "webpack serve --mode=development --config-name dynamic",
         "test": "vitest run",

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -6,6 +6,7 @@ const { ALL_PLATFORM_IDS } = require('./platforms')
 const DIST_DIR = path.resolve(__dirname, '../dist')
 const OUT_DIR = path.join(DIST_DIR, 'publish')
 const BUILT_FILE = path.join(DIST_DIR, 'playgama-bridge.js')
+const CHUNKS_DIR = path.join(DIST_DIR, 'platform-bridges')
 
 const args = process.argv.slice(2)
 
@@ -16,14 +17,18 @@ const getArg = (name) => {
 }
 
 if (args.includes('--help') || args.includes('--list')) {
-    console.info('Usage: node scripts/build-dist.js --scope=all|base|platforms [--platform=<id>]')
+    console.info('Usage: node scripts/build-dist.js [--type=both|dynamic|standalone] [--platform=<id>] [--public-path=<url>]')
     console.info('Available platforms:', ALL_PLATFORM_IDS.join(', '))
     process.exit(0)
 }
 
-const scope = getArg('scope') || 'all'
-if (!['all', 'base', 'platforms'].includes(scope)) {
-    console.error(`Unknown scope: ${scope}. Use one of: all, base, platforms`)
+// Absolute URL the dynamic bundle uses to fetch its platform-bridges/ chunks.
+// Should match the deploy location, e.g. https://<domain>/v<major>/<channel>/
+const publicPath = getArg('public-path')
+
+const type = getArg('type') || 'both'
+if (!['both', 'dynamic', 'standalone'].includes(type)) {
+    console.error(`Unknown type: ${type}. Use one of: both, dynamic, standalone`)
     process.exit(1)
 }
 
@@ -39,42 +44,62 @@ const run = (command) => {
     execSync(command, { stdio: 'inherit' })
 }
 
-const collect = (targetName) => {
+const ensureBuilt = () => {
     if (!fs.existsSync(BUILT_FILE)) {
         console.error(`Expected build output not found: ${BUILT_FILE}`)
         process.exit(1)
     }
-    const dest = path.join(OUT_DIR, targetName)
+}
+
+const collect = (src, relDest) => {
+    const dest = path.join(OUT_DIR, relDest)
     fs.mkdirSync(path.dirname(dest), { recursive: true })
-    fs.copyFileSync(BUILT_FILE, dest)
+    fs.copyFileSync(src, dest)
     const { size } = fs.statSync(dest)
-    console.info(`-> ${targetName} (${(size / 1024).toFixed(1)} KB)`)
+    console.info(`-> ${relDest.split(path.sep).join('/')} (${(size / 1024).toFixed(1)} KB)`)
 }
 
 fs.rmSync(OUT_DIR, { recursive: true, force: true })
 fs.mkdirSync(OUT_DIR, { recursive: true })
 
-const buildBase = scope === 'all' || scope === 'base'
-const buildPlatforms = scope === 'all' || scope === 'platforms'
+const buildDynamic = type === 'both' || type === 'dynamic'
+const buildStandalone = type === 'both' || type === 'standalone'
 
-if (buildBase) {
-    console.info('\n=== Building base bundle (all platforms) ===')
-    run('npx webpack --config-name bundled --env noLint')
-    collect('playgama-bridge.js')
+if (buildDynamic && !publicPath) {
+    console.error('--public-path=<url> is required when building the dynamic bundle')
+    console.error('e.g. --public-path=https://bridge.playgama.com/v1/stable/')
+    process.exit(1)
 }
 
-if (buildPlatforms) {
+// Dynamic first: it writes dist/platform-bridges/ which later standalone builds wipe.
+if (buildDynamic) {
+    console.info('\n=== Building dynamic bundle (main + platform chunks) ===')
+    const publicPathArg = publicPath ? ` --env publicPath=${publicPath}` : ''
+    run(`npx webpack --config-name dynamic --env noLint${publicPathArg}`)
+    ensureBuilt()
+    collect(BUILT_FILE, 'playgama-bridge.js')
+    if (!fs.existsSync(CHUNKS_DIR)) {
+        console.error(`Expected chunks dir not found: ${CHUNKS_DIR}`)
+        process.exit(1)
+    }
+    fs.cpSync(CHUNKS_DIR, path.join(OUT_DIR, 'platform-bridges'), { recursive: true })
+    const chunks = fs.readdirSync(CHUNKS_DIR).filter((n) => n.endsWith('.js'))
+    console.info(`-> platform-bridges/ (${chunks.length} chunk file(s))`)
+}
+
+if (buildStandalone) {
     const platforms = singlePlatform ? [singlePlatform] : ALL_PLATFORM_IDS
-    console.info(`\n=== Building ${platforms.length} per-platform bundle(s) ===`)
-    for (const id of platforms) {
+    console.info(`\n=== Building ${platforms.length} standalone bundle(s) ===`)
+    platforms.forEach((id) => {
         console.info(`\n--- ${id} ---`)
         run(`npx webpack --env platform=${id} --env noLint`)
-        collect(path.join('platform-bridges', `${id}.js`))
-    }
+        ensureBuilt()
+        collect(BUILT_FILE, path.join('standalone', id, 'playgama-bridge.js'))
+    })
 }
 
 const produced = fs.readdirSync(OUT_DIR, { recursive: true })
-    .filter((name) => name.endsWith('.js'))
+    .filter((name) => typeof name === 'string' && name.endsWith('.js'))
     .sort()
 console.info(`\n=== Done. ${produced.length} file(s) in dist/publish/ ===`)
 produced.forEach((name) => console.info(`  ${name.split(path.sep).join('/')}`))

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -1,0 +1,80 @@
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const { ALL_PLATFORM_IDS } = require('./platforms')
+
+const DIST_DIR = path.resolve(__dirname, '../dist')
+const OUT_DIR = path.join(DIST_DIR, 'publish')
+const BUILT_FILE = path.join(DIST_DIR, 'playgama-bridge.js')
+
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+    const prefix = `--${name}=`
+    const arg = args.find((a) => a.startsWith(prefix))
+    return arg ? arg.slice(prefix.length) : undefined
+}
+
+if (args.includes('--help') || args.includes('--list')) {
+    console.info('Usage: node scripts/build-dist.js --scope=all|base|platforms [--platform=<id>]')
+    console.info('Available platforms:', ALL_PLATFORM_IDS.join(', '))
+    process.exit(0)
+}
+
+const scope = getArg('scope') || 'all'
+if (!['all', 'base', 'platforms'].includes(scope)) {
+    console.error(`Unknown scope: ${scope}. Use one of: all, base, platforms`)
+    process.exit(1)
+}
+
+const singlePlatform = getArg('platform')
+if (singlePlatform && !ALL_PLATFORM_IDS.includes(singlePlatform)) {
+    console.error(`Unknown platform: ${singlePlatform}`)
+    console.error(`Available: ${ALL_PLATFORM_IDS.join(', ')}`)
+    process.exit(1)
+}
+
+const run = (command) => {
+    console.info(`\n$ ${command}`)
+    execSync(command, { stdio: 'inherit' })
+}
+
+const collect = (targetName) => {
+    if (!fs.existsSync(BUILT_FILE)) {
+        console.error(`Expected build output not found: ${BUILT_FILE}`)
+        process.exit(1)
+    }
+    const dest = path.join(OUT_DIR, targetName)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.copyFileSync(BUILT_FILE, dest)
+    const { size } = fs.statSync(dest)
+    console.info(`-> ${targetName} (${(size / 1024).toFixed(1)} KB)`)
+}
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true })
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+const buildBase = scope === 'all' || scope === 'base'
+const buildPlatforms = scope === 'all' || scope === 'platforms'
+
+if (buildBase) {
+    console.info('\n=== Building base bundle (all platforms) ===')
+    run('npx webpack --config-name bundled --env noLint')
+    collect('playgama-bridge.js')
+}
+
+if (buildPlatforms) {
+    const platforms = singlePlatform ? [singlePlatform] : ALL_PLATFORM_IDS
+    console.info(`\n=== Building ${platforms.length} per-platform bundle(s) ===`)
+    for (const id of platforms) {
+        console.info(`\n--- ${id} ---`)
+        run(`npx webpack --env platform=${id} --env noLint`)
+        collect(path.join('platform-bridges', `${id}.js`))
+    }
+}
+
+const produced = fs.readdirSync(OUT_DIR, { recursive: true })
+    .filter((name) => name.endsWith('.js'))
+    .sort()
+console.info(`\n=== Done. ${produced.length} file(s) in dist/publish/ ===`)
+produced.forEach((name) => console.info(`  ${name.split(path.sep).join('/')}`))

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,7 +7,6 @@ const packageJson = require('./package.json')
 const { ALL_PLATFORM_IDS } = require('./scripts/platforms')
 
 const platformDirName = 'platform-bridges'
-const CDN_BASE_URL = `https://bridge.playgama.com/v${packageJson.version.split('.')[0]}/stable/`
 
 class CleanPlatformsPlugin {
     apply(compiler) {
@@ -22,11 +21,12 @@ class CleanPlatformsPlugin {
 
 const createPlatformDefines = (targetPlatforms) => {
     const includeAll = targetPlatforms.length === 0
-    const defines = {}
-    for (const id of ALL_PLATFORM_IDS) {
-        defines[`__INCLUDE_${id.toUpperCase()}__`] = includeAll || targetPlatforms.includes(id)
-    }
-    return defines
+    return Object.fromEntries(
+        ALL_PLATFORM_IDS.map((id) => [
+            `__INCLUDE_${id.toUpperCase()}__`,
+            includeAll || targetPlatforms.includes(id),
+        ]),
+    )
 }
 
 const createConfig = (targetPlatforms = [], { noLint = false } = {}) => ({
@@ -112,7 +112,7 @@ module.exports = (env = {}, argv = {}) => {
             name: 'platform',
             output: {
                 filename: 'playgama-bridge.js',
-                path: path.resolve(__dirname, `dist`),
+                path: path.resolve(__dirname, 'dist'),
                 publicPath: 'auto',
             },
             plugins: [
@@ -131,7 +131,7 @@ module.exports = (env = {}, argv = {}) => {
         name: 'dynamic',
         output: {
             ...baseConfig.output,
-            publicPath: isDevelopment ? 'auto' : CDN_BASE_URL,
+            publicPath: isDevelopment ? 'auto' : env.publicPath,
         },
         plugins: [
             ...baseConfig.plugins,


### PR DESCRIPTION
## Context

Publishing the Playgama Bridge SDK to S3/CDN is currently fully manual. This adds a manual, button-triggered GitHub Actions pipeline that runs tests, builds, and uploads to the `bridge.playgama.com` S3 bucket served via Gcore CDN.

Target artifacts in the delivery channel:
- `https://bridge.playgama.com/v1/{channel}/playgama-bridge.js` — base bundle with all platforms (single file).
- `https://bridge.playgama.com/v1/{channel}/{PLATFORM_ID}.playgama-bridge.js` — self-contained single-file build per platform, no extra chunks.

## Changes

- **`scripts/build-dist.js`** — orchestrates builds into a clean `dist-publish/` dir. Supports `--scope=all|base|platforms` and optional `--platform=<id>` (validated against `ALL_PLATFORM_IDS`). Base uses the bundled config; per-platform uses `webpack --env platform=<id>` (single chunk, self-contained).
- **`.github/workflows/publish.yml`** — manual `workflow_dispatch` with inputs `channel` (dev/stable), `scope`, and optional `platform`. Jobs: **verify** (lint + test) → **build** (artifact) → **publish** (`aws s3 cp` to `v{major}/{channel}/`). The S3 prefix is derived from the major version in `package.json`, so the same workflow will work for v2 from its branch. A guard fails the run if `channel=stable` is selected from any branch other than `main`.
- **`package.json`** — adds the `build:dist` script.
- **`.gitignore`** — ignores `dist-publish`.

## Notes

- AWS auth uses static `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets (matching the org pattern in `portal-frontend-vue`). The IAM policy behind them needs `s3:PutObject` on `bridge.playgama.com`.
- CDN cache purge is intentionally omitted for now; updates appear after the 12h Gcore edge TTL or a manual purge.
- Rollout order: run with `channel=dev` first to validate the pipeline on `v1/dev/`, then `channel=stable` from `main`.

## Verification

Local runs confirmed:
- `node scripts/build-dist.js --scope=base` → `playgama-bridge.js` (~591 KB, all platforms inlined).
- `node scripts/build-dist.js --scope=platforms --platform=crazy_games` → `crazy_games.playgama-bridge.js` (~219 KB), single self-contained file.