### PR TITLE
CD: publish v2 builds to CDN (staging/production)

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,24 @@
+name: Release to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Target channel (S3 folder v<major>/<channel>/)
+        type: choice
+        default: stable
+        options:
+          - stable
+          - latest
+          - dev
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      environment: production
+      channel: ${{ inputs.channel }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET_PRODUCTION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,103 @@
+name: Publish (reusable)
+
+# Reusable workflow: verify -> build -> upload to an S3 bucket.
+# Not triggered directly. Called by staging.yml / production.yml.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: staging | production (drives the release-branch guard)
+        type: string
+        required: true
+      channel:
+        description: stable | latest | dev (S3 folder v<major>/<channel>/)
+        type: string
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      S3_BUCKET:
+        required: true
+
+env:
+  AWS_REGION: eu-central-1
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard production to release branches
+        if: ${{ inputs.environment == 'production' && github.ref_name != 'main' && github.ref_name != 'develop-v2' }}
+        run: |
+          echo "::error::production is only allowed from 'main' or 'develop-v2' (got '${{ github.ref_name }}')."
+          exit 1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Build artifacts
+        env:
+          BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          if [ -z "${BUCKET}" ]; then
+            echo "::error::S3_BUCKET secret is empty."
+            exit 1
+          fi
+          MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+          PUBLIC_PATH="https://${BUCKET}/v${MAJOR}/${{ inputs.channel }}/"
+          npm run build:dist -- --type=both --public-path="$PUBLIC_PATH"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-publish
+          path: dist/publish/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-publish
+          path: dist/publish
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Upload to S3
+        env:
+          BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          if [ -z "${BUCKET}" ]; then
+            echo "::error::S3_BUCKET secret is empty."
+            exit 1
+          fi
+          MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+          DEST="v${MAJOR}/${{ inputs.channel }}"
+          echo "Publishing ${{ inputs.environment }}/${{ inputs.channel }} -> s3://***/${DEST}/"
+          aws s3 cp dist/publish/ "s3://${BUCKET}/${DEST}/" \
+            --recursive \
+            --content-type application/javascript \
+            --no-progress
+      # CDN cache purge is intentionally omitted for now.

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,24 @@
+name: Release to Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Target channel (S3 folder v<major>/<channel>/)
+        type: choice
+        default: dev
+        options:
+          - dev
+          - stable
+          - latest
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      environment: staging
+      channel: ${{ inputs.channel }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "build:bundled": "webpack --config-name bundled",
         "build:nolint": "webpack --config-name bundled --env noLint",
         "build:platform": "ts-node scripts/build-platform.ts",
+        "build:dist": "ts-node scripts/build-dist.ts",
         "develop": "webpack --mode=development",
         "dev": "webpack serve --mode=development --config-name dynamic",
         "test": "vitest run",

--- a/scripts/build-dist.ts
+++ b/scripts/build-dist.ts
@@ -1,0 +1,105 @@
+import { execSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import { ALL_PLATFORM_IDS } from './platforms'
+
+const DIST_DIR = path.resolve(__dirname, '../dist')
+const OUT_DIR = path.join(DIST_DIR, 'publish')
+const BUILT_FILE = path.join(DIST_DIR, 'playgama-bridge.js')
+const CHUNKS_DIR = path.join(DIST_DIR, 'platform-bridges')
+
+const args = process.argv.slice(2)
+
+const getArg = (name: string): string | undefined => {
+    const prefix = `--${name}=`
+    const arg = args.find((a) => a.startsWith(prefix))
+    return arg ? arg.slice(prefix.length) : undefined
+}
+
+if (args.includes('--help') || args.includes('--list')) {
+    console.info('Usage: ts-node scripts/build-dist.ts [--type=both|dynamic|standalone] [--platform=<id>] [--public-path=<url>]')
+    console.info('Available platforms:', ALL_PLATFORM_IDS.join(', '))
+    process.exit(0)
+}
+
+// Absolute URL the dynamic bundle uses to fetch its platform-bridges/ chunks.
+// Should match the deploy location, e.g. https://<domain>/v<major>/<channel>/
+const publicPath = getArg('public-path')
+
+const type = getArg('type') || 'both'
+if (!['both', 'dynamic', 'standalone'].includes(type)) {
+    console.error(`Unknown type: ${type}. Use one of: both, dynamic, standalone`)
+    process.exit(1)
+}
+
+const singlePlatform = getArg('platform')
+if (singlePlatform && !ALL_PLATFORM_IDS.includes(singlePlatform)) {
+    console.error(`Unknown platform: ${singlePlatform}`)
+    console.error(`Available: ${ALL_PLATFORM_IDS.join(', ')}`)
+    process.exit(1)
+}
+
+const run = (command: string): void => {
+    console.info(`\n$ ${command}`)
+    execSync(command, { stdio: 'inherit' })
+}
+
+const ensureBuilt = (): void => {
+    if (!fs.existsSync(BUILT_FILE)) {
+        console.error(`Expected build output not found: ${BUILT_FILE}`)
+        process.exit(1)
+    }
+}
+
+const collect = (src: string, relDest: string): void => {
+    const dest = path.join(OUT_DIR, relDest)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.copyFileSync(src, dest)
+    const { size } = fs.statSync(dest)
+    console.info(`-> ${relDest.split(path.sep).join('/')} (${(size / 1024).toFixed(1)} KB)`)
+}
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true })
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+const buildDynamic = type === 'both' || type === 'dynamic'
+const buildStandalone = type === 'both' || type === 'standalone'
+
+if (buildDynamic && !publicPath) {
+    console.error('--public-path=<url> is required when building the dynamic bundle')
+    console.error('e.g. --public-path=https://bridge.playgama.com/v2/stable/')
+    process.exit(1)
+}
+
+// Dynamic first: it writes dist/platform-bridges/ which later standalone builds wipe.
+if (buildDynamic) {
+    console.info('\n=== Building dynamic bundle (main + platform chunks) ===')
+    const publicPathArg = publicPath ? ` --env publicPath=${publicPath}` : ''
+    run(`npx webpack --config-name dynamic --env noLint${publicPathArg}`)
+    ensureBuilt()
+    collect(BUILT_FILE, 'playgama-bridge.js')
+    if (!fs.existsSync(CHUNKS_DIR)) {
+        console.error(`Expected chunks dir not found: ${CHUNKS_DIR}`)
+        process.exit(1)
+    }
+    fs.cpSync(CHUNKS_DIR, path.join(OUT_DIR, 'platform-bridges'), { recursive: true })
+    const chunks = fs.readdirSync(CHUNKS_DIR).filter((n) => n.endsWith('.js'))
+    console.info(`-> platform-bridges/ (${chunks.length} chunk file(s))`)
+}
+
+if (buildStandalone) {
+    const platforms = singlePlatform ? [singlePlatform] : ALL_PLATFORM_IDS
+    console.info(`\n=== Building ${platforms.length} standalone bundle(s) ===`)
+    platforms.forEach((id) => {
+        console.info(`\n--- ${id} ---`)
+        run(`npx webpack --env platform=${id} --env noLint`)
+        ensureBuilt()
+        collect(BUILT_FILE, path.join('standalone', id, 'playgama-bridge.js'))
+    })
+}
+
+const produced = fs.readdirSync(OUT_DIR, { recursive: true })
+    .filter((name): name is string => typeof name === 'string' && name.endsWith('.js'))
+    .sort()
+console.info(`\n=== Done. ${produced.length} file(s) in dist/publish/ ===`)
+produced.forEach((name) => console.info(`  ${name.split(path.sep).join('/')}`))

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -8,7 +8,6 @@ import packageJson from './package.json'
 import { ALL_PLATFORM_IDS } from './scripts/platforms'
 
 const platformDirName = 'platform-bridges'
-const CDN_BASE_URL = `https://bridge.playgama.com/v${packageJson.version.split('.')[0]}/stable/`
 
 class CleanPlatformsPlugin {
     apply(compiler: Compiler): void {
@@ -121,6 +120,9 @@ const createConfig = (targetPlatforms: string[] = [], { noLint = false }: Create
 interface WebpackEnv {
     platform?: string
     noLint?: boolean
+    // Absolute URL the dynamic bundle uses to fetch its platform-bridges/ chunks.
+    // Should match the deploy location, e.g. https://<domain>/v<major>/<channel>/
+    publicPath?: string
 }
 
 interface WebpackArgv {
@@ -159,7 +161,7 @@ export default (env: WebpackEnv = {}, argv: WebpackArgv = {}): Configuration | C
         name: 'dynamic',
         output: {
             ...baseConfig.output,
-            publicPath: isDevelopment ? 'auto' : CDN_BASE_URL,
+            publicPath: isDevelopment ? 'auto' : env.publicPath,
         },
         plugins: [
             ...(baseConfig.plugins ?? []),


### PR DESCRIPTION
## What & why

Ports the CDN build-publishing CI-CD from `main` (v1) into `develop-v2`, so the second major version can be released to all channels (**stable / latest / dev**) on **staging** and **production** straight from the v2 branch.

A straight cherry-pick was not possible: in v2 the build system moved to TypeScript and diverged from main (no `build-dist.js`, publicPath hardcoded in webpack). So the CD is **adapted** to v2 rather than copied.

## Changes

- **`webpack.config.ts`** — dynamic bundle publicPath is now parameterized via `--env publicPath` (drops the hardcoded `CDN_BASE_URL`, which was pinned to `stable`). Without this, chunks would always load from `v2/stable/`.
- **`scripts/build-dist.ts`** — TS port of the `dynamic + standalone` orchestrator → `dist/publish/`.
- **`package.json`** — `build:dist` script (via `ts-node`).
- **`.github/workflows/publish.yml`** — reusable: verify (lint + test) → build → upload to S3 `v<major>/<channel>/`.
- **`.github/workflows/production.yml`** / **`staging.yml`** — manual trigger only (`workflow_dispatch`) with channel selection.
- Production guard relaxed: branches **`main`** and **`develop-v2`** are allowed.

The major version comes from `package.json` (currently `2.0.0-rc.1`), so uploads automatically target `v2/<channel>/`.

## Verified locally

- `npm run lint` — passed
- `npm run build:dist -- --type=dynamic --public-path=...` — passed; the public-path is correctly baked into the bundle (chunks load from the given `v2/<channel>/`).

## Required on the repo side (secrets)

Same as the v1 CD: `BRIDGE_AWS_ACCESS_KEY_ID`, `BRIDGE_AWS_SECRET_ACCESS_KEY`, `S3_BUCKET_STAGING`, `S3_BUCKET_PRODUCTION`.