### PR TITLE
Enable advanced banners support in StandalonePlatformBridge

### DIFF
--- a/src/platform-bridges/StandalonePlatformBridge.js
+++ b/src/platform-bridges/StandalonePlatformBridge.js
@@ -35,7 +35,7 @@ class StandalonePlatformBridge extends PlaygamaPlatformBridge {
         return true
     }
 
-    _isAdvancedBannersSupported = false
+    _isAdvancedBannersSupported = true
 }
 
 export default StandalonePlatformBridge


### PR DESCRIPTION
Advanced banners are now supported in the Standalone Platform. You can use them to display ads above your game's frame.