### PR TITLE
Restrict production releases to the main branch

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,9 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Guard production to release branches
-        if: ${{ inputs.environment == 'production' && github.ref_name != 'main' && github.ref_name != 'develop-v2' }}
+        if: ${{ inputs.environment == 'production' && github.ref_name != 'main' }}
         run: |
-          echo "::error::production is only allowed from 'main' or 'develop-v2' (got '${{ github.ref_name }}')."
+          echo "::error::production is only allowed from 'main' (got '${{ github.ref_name }}')."
           exit 1
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What

Removes the temporary `develop-v2` exception from the production deploy guard in `.github/workflows/publish.yml`. Production dispatches are now allowed only from the `main` branch; dispatching to `production` from any other branch (including `develop-v2`) fails at the verify guard step. Staging deploys are unaffected and can still be triggered from any branch.

## Why

`develop-v2` has been merged into `main`, so the temporary exception is no longer needed and only weakens the production guard.