### PR TITLE
Prevent stale recorder capture callbacks

### DIFF
--- a/src/lib/Recorder.ts
+++ b/src/lib/Recorder.ts
@@ -40,6 +40,8 @@ export type RecorderStartedCallback = () => void
 export type RecorderErrorCallback = (reason: string | null) => void
 
 class Recorder {
+    #captureGeneration = 0
+
     #pc: RTCPeerConnection | null = null
 
     #stream: MediaStream | null = null
@@ -85,27 +87,46 @@ class Recorder {
             return
         }
 
-        this.#stream = canvas.captureStream(options.fps || 30)
+        this.#captureGeneration += 1
+        const generation = this.#captureGeneration
+        this.#clearCaptureResources()
+        const stream = canvas.captureStream(options.fps || 30)
+        this.#stream = stream
+        let peerConnection: RTCPeerConnection
+        try {
+            peerConnection = new RTCPeerConnection()
+        } catch (error) {
+            this.#clearCaptureResources()
+            throw error
+        }
+        this.#pc = peerConnection
 
         if (options.contentHint) {
-            const track = this.#stream.getVideoTracks()[0]
+            const track = stream.getVideoTracks()[0]
             if (track) track.contentHint = options.contentHint
         }
 
-        this.#pc = new RTCPeerConnection()
+        stream.getTracks().forEach((track) => peerConnection.addTrack(track, stream))
 
-        this.#stream.getTracks().forEach((t) => this.#pc!.addTrack(t, this.#stream!))
-
-        this.#pc.onicecandidate = (e) => {
-            if (e.candidate) {
+        peerConnection.onicecandidate = (e) => {
+            if (e.candidate && this.#isCurrentCapture(generation, peerConnection)) {
                 this.#onIceCandidate?.(e.candidate.toJSON())
             }
         }
 
-        const offer = await this.#pc.createOffer()
-        await this.#pc.setLocalDescription(offer)
+        let offer: RTCSessionDescriptionInit
+        try {
+            offer = await peerConnection.createOffer()
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+            await peerConnection.setLocalDescription(offer)
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+        } catch (error) {
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+            this.#clearCaptureResources()
+            throw error
+        }
 
-        this.#applyEncodingParams(options)
+        this.#applyEncodingParams(peerConnection, options)
 
         this.#onOffer?.(offer.sdp)
         this.#onStarted?.()
@@ -126,22 +147,30 @@ class Recorder {
     }
 
     stopCapture(): void {
+        this.#captureGeneration += 1
+        this.#clearCaptureResources()
+    }
+
+    #clearCaptureResources(): void {
         this.#stream?.getTracks().forEach((t) => t.stop())
         this.#pc?.close()
         this.#pc = null
         this.#stream = null
     }
 
-    #applyEncodingParams({
-        maxBitrate,
-        minBitrate,
-        maxFramerate,
-        scaleResolutionDownBy,
-        priority,
-        networkPriority,
-        scalabilityMode,
-    }: RecorderStartOptions): void {
-        this.#pc?.getSenders().forEach((sender) => {
+    #applyEncodingParams(
+        peerConnection: RTCPeerConnection,
+        {
+            maxBitrate,
+            minBitrate,
+            maxFramerate,
+            scaleResolutionDownBy,
+            priority,
+            networkPriority,
+            scalabilityMode,
+        }: RecorderStartOptions,
+    ): void {
+        peerConnection.getSenders().forEach((sender) => {
             if (sender.track?.kind !== 'video') return
             const params = sender.getParameters()
             if (!params.encodings?.length) {
@@ -171,6 +200,13 @@ class Recorder {
             }
             sender.setParameters(params)
         })
+    }
+
+    #isCurrentCapture(
+        generation: number,
+        peerConnection: RTCPeerConnection,
+    ): boolean {
+        return generation === this.#captureGeneration && peerConnection === this.#pc
     }
 
     #getCanvas(): HTMLCanvasElement | null {

--- a/tests/src/lib/recorder.spec.ts
+++ b/tests/src/lib/recorder.spec.ts
@@ -155,6 +155,38 @@ describe('Recorder', () => {
             expect(canvas.captureStream).toHaveBeenCalledWith(30)
         })
 
+        test('should stop the stream when peer connection creation fails', async () => {
+            const stop = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop }],
+            })
+            global.RTCPeerConnection = vi.fn().mockImplementation(() => {
+                throw new Error('Peer connection creation failed')
+            }) as unknown as typeof RTCPeerConnection
+
+            const module = createRecorder()
+
+            await expect(module.startCapture()).rejects.toThrow('Peer connection creation failed')
+            expect(stop).toHaveBeenCalledOnce()
+        })
+
+        test('should release capture resources when offer creation fails', async () => {
+            const stop = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop }],
+            })
+            const mockPc = createMockRTCPeerConnection()
+            mockPc.createOffer = vi.fn().mockRejectedValue(new Error('Offer creation failed'))
+
+            const module = createRecorder()
+
+            await expect(module.startCapture()).rejects.toThrow('Offer creation failed')
+            expect(stop).toHaveBeenCalledOnce()
+            expect(mockPc.close).toHaveBeenCalledOnce()
+        })
+
         test('should apply maxBitrate to video sender', async () => {
             canvas = createMockCanvas()
             const mockPc = createMockRTCPeerConnection()
@@ -251,6 +283,50 @@ describe('Recorder', () => {
 
             const module = createRecorder()
             await expect(module.startCapture()).resolves.toBeUndefined()
+        })
+
+        test('should not emit an old offer after a newer capture starts', async () => {
+            canvas = createMockCanvas()
+            const firstPc = createMockRTCPeerConnection()
+            const secondPc = createMockRTCPeerConnection()
+            let resolveFirstOffer!: (offer: RTCSessionDescriptionInit) => void
+            firstPc.createOffer = vi.fn(() => new Promise((resolve) => {
+                resolveFirstOffer = resolve
+            }))
+            secondPc.createOffer = vi.fn().mockResolvedValue({
+                sdp: 'fresh-offer-sdp',
+                type: 'offer',
+            })
+            global.RTCPeerConnection = vi.fn()
+                .mockImplementationOnce(() => firstPc)
+                .mockImplementationOnce(() => secondPc) as unknown as typeof RTCPeerConnection
+            const onOffer = vi.fn()
+            const onIceCandidate = vi.fn()
+            const onStarted = vi.fn()
+            const module = createRecorder()
+            module.onOffer = onOffer
+            module.onIceCandidate = onIceCandidate
+            module.onStarted = onStarted
+
+            const firstStart = module.startCapture()
+            await vi.waitFor(() => expect(firstPc.createOffer).toHaveBeenCalled())
+            module.stopCapture()
+            await module.startCapture()
+            resolveFirstOffer({ sdp: 'stale-offer-sdp', type: 'offer' })
+            await firstStart
+            firstPc.onicecandidate?.({
+                candidate: { toJSON: () => ({ candidate: 'stale-candidate' }) },
+            })
+            secondPc.onicecandidate?.({
+                candidate: { toJSON: () => ({ candidate: 'fresh-candidate' }) },
+            })
+
+            expect(onOffer).toHaveBeenCalledOnce()
+            expect(onOffer).toHaveBeenCalledWith('fresh-offer-sdp')
+            expect(onIceCandidate).toHaveBeenCalledOnce()
+            expect(onIceCandidate).toHaveBeenCalledWith({ candidate: 'fresh-candidate' })
+            expect(onStarted).toHaveBeenCalledOnce()
+            expect(firstPc.setLocalDescription).not.toHaveBeenCalled()
         })
     })
 


### PR DESCRIPTION
## What changed

- Ignore SDP and ICE callbacks from capture attempts that were stopped or replaced.
- Keep asynchronous WebRTC work bound to the peer connection that created it.
- Release stream and peer-connection resources when initialization or offer creation fails.
- Add regression coverage for stale offers, stale ICE candidates, and failed initialization.

## Root cause

An older `startCapture()` could complete after a newer capture and publish its SDP last. Consumers cannot reliably identify that stale offer without protocol-level correlation, so cancellation is enforced by the Recorder that owns the asynchronous lifecycle.

## Verification

- `npm test` — 93/93 passed
- `npm run lint`
- `npm run build`
