### PR TITLE
Prevent stale recorder capture callbacks

### DIFF
--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -16,6 +16,8 @@
  */
 
 class RecorderModule {
+    #captureGeneration = 0
+
     #pc = null
 
     #stream = null
@@ -79,27 +81,46 @@ class RecorderModule {
 
         const canvas = this.#getCanvas()
 
-        this.#stream = canvas.captureStream(options.fps || 30)
+        this.#captureGeneration += 1
+        const generation = this.#captureGeneration
+        this.#clearCaptureResources()
+        const stream = canvas.captureStream(options.fps || 30)
+        this.#stream = stream
+        let peerConnection
+        try {
+            peerConnection = new RTCPeerConnection()
+        } catch (error) {
+            this.#clearCaptureResources()
+            throw error
+        }
+        this.#pc = peerConnection
 
         if (options.contentHint) {
-            const track = this.#stream.getVideoTracks()[0]
+            const track = stream.getVideoTracks()[0]
             if (track) track.contentHint = options.contentHint
         }
 
-        this.#pc = new RTCPeerConnection()
+        stream.getTracks().forEach((track) => peerConnection.addTrack(track, stream))
 
-        this.#stream.getTracks().forEach((t) => this.#pc.addTrack(t, this.#stream))
-
-        this.#pc.onicecandidate = (e) => {
-            if (e.candidate) {
+        peerConnection.onicecandidate = (e) => {
+            if (e.candidate && this.#isCurrentCapture(generation, peerConnection)) {
                 this.#onIceCandidate?.(e.candidate.toJSON())
             }
         }
 
-        const offer = await this.#pc.createOffer()
-        await this.#pc.setLocalDescription(offer)
+        let offer
+        try {
+            offer = await peerConnection.createOffer()
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+            await peerConnection.setLocalDescription(offer)
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+        } catch (error) {
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+            this.#clearCaptureResources()
+            throw error
+        }
 
-        this.#applyEncodingParams(options)
+        this.#applyEncodingParams(peerConnection, options)
 
         this.#onOffer?.(offer.sdp)
         this.#onStarted?.()
@@ -146,13 +167,18 @@ class RecorderModule {
 
     /** Stops the capture, closes the peer connection and releases all tracks. */
     stopCapture() {
+        this.#captureGeneration += 1
+        this.#clearCaptureResources()
+    }
+
+    #clearCaptureResources() {
         this.#stream?.getTracks().forEach((t) => t.stop())
         this.#pc?.close()
         this.#pc = null
         this.#stream = null
     }
 
-    #applyEncodingParams({
+    #applyEncodingParams(peerConnection, {
         maxBitrate,
         minBitrate,
         maxFramerate,
@@ -161,7 +187,7 @@ class RecorderModule {
         networkPriority,
         scalabilityMode,
     }) {
-        this.#pc.getSenders().forEach((sender) => {
+        peerConnection.getSenders().forEach((sender) => {
             if (sender.track?.kind !== 'video') return
             const params = sender.getParameters()
             if (!params.encodings?.length) {
@@ -190,6 +216,10 @@ class RecorderModule {
             }
             sender.setParameters(params)
         })
+    }
+
+    #isCurrentCapture(generation, peerConnection) {
+        return generation === this.#captureGeneration && peerConnection === this.#pc
     }
 
     #getCanvas() {

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -152,6 +152,38 @@ describe('RecorderModule', () => {
             expect(canvas.captureStream).toHaveBeenCalledWith(30)
         })
 
+        test('should stop the stream when peer connection creation fails', async () => {
+            const stop = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop }],
+            })
+            global.RTCPeerConnection = vi.fn().mockImplementation(() => {
+                throw new Error('Peer connection creation failed')
+            }) as unknown as typeof RTCPeerConnection
+
+            const module = createRecorderModule()
+
+            await expect(module.startCapture()).rejects.toThrow('Peer connection creation failed')
+            expect(stop).toHaveBeenCalledOnce()
+        })
+
+        test('should release capture resources when offer creation fails', async () => {
+            const stop = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop }],
+            })
+            const mockPc = createMockRTCPeerConnection()
+            mockPc.createOffer = vi.fn().mockRejectedValue(new Error('Offer creation failed'))
+
+            const module = createRecorderModule()
+
+            await expect(module.startCapture()).rejects.toThrow('Offer creation failed')
+            expect(stop).toHaveBeenCalledOnce()
+            expect(mockPc.close).toHaveBeenCalledOnce()
+        })
+
         test('should apply maxBitrate to video sender', async () => {
             canvas = createMockCanvas()
             const mockPc = createMockRTCPeerConnection()
@@ -248,6 +280,50 @@ describe('RecorderModule', () => {
 
             const module = createRecorderModule()
             await expect(module.startCapture()).resolves.toBeUndefined()
+        })
+
+        test('should not emit an old offer after a newer capture starts', async () => {
+            canvas = createMockCanvas()
+            const firstPc = createMockRTCPeerConnection()
+            const secondPc = createMockRTCPeerConnection()
+            let resolveFirstOffer!: (offer: RTCSessionDescriptionInit) => void
+            firstPc.createOffer = vi.fn(() => new Promise((resolve) => {
+                resolveFirstOffer = resolve
+            }))
+            secondPc.createOffer = vi.fn().mockResolvedValue({
+                sdp: 'fresh-offer-sdp',
+                type: 'offer',
+            })
+            global.RTCPeerConnection = vi.fn()
+                .mockImplementationOnce(() => firstPc)
+                .mockImplementationOnce(() => secondPc) as unknown as typeof RTCPeerConnection
+            const onOffer = vi.fn()
+            const onIceCandidate = vi.fn()
+            const onStarted = vi.fn()
+            const module = createRecorderModule()
+            module.onOffer = onOffer
+            module.onIceCandidate = onIceCandidate
+            module.onStarted = onStarted
+
+            const firstStart = module.startCapture()
+            await vi.waitFor(() => expect(firstPc.createOffer).toHaveBeenCalled())
+            module.stopCapture()
+            await module.startCapture()
+            resolveFirstOffer({ sdp: 'stale-offer-sdp', type: 'offer' })
+            await firstStart
+            firstPc.onicecandidate?.({
+                candidate: { toJSON: () => ({ candidate: 'stale-candidate' }) },
+            })
+            secondPc.onicecandidate?.({
+                candidate: { toJSON: () => ({ candidate: 'fresh-candidate' }) },
+            })
+
+            expect(onOffer).toHaveBeenCalledOnce()
+            expect(onOffer).toHaveBeenCalledWith('fresh-offer-sdp')
+            expect(onIceCandidate).toHaveBeenCalledOnce()
+            expect(onIceCandidate).toHaveBeenCalledWith({ candidate: 'fresh-candidate' })
+            expect(onStarted).toHaveBeenCalledOnce()
+            expect(firstPc.setLocalDescription).not.toHaveBeenCalled()
         })
     })
 


### PR DESCRIPTION
## What changed

- Ignore SDP and ICE callbacks from capture attempts that were stopped or replaced.
- Keep asynchronous WebRTC work bound to the peer connection that created it.
- Release stream and peer-connection resources when initialization or offer creation fails.
- Add regression coverage for stale offers, stale ICE candidates, and failed initialization.

## Root cause

An older `startCapture()` could complete after a newer capture and publish its SDP last. Consumers cannot reliably identify that stale offer without protocol-level correlation, so cancellation is enforced by the Recorder module that owns the asynchronous lifecycle.

## Verification

- `npm test` — 102/102 passed
- `npm run lint`
- `npm run build`
