### PR TITLE
Queue recorder ICE candidates until remote answer

### DIFF
--- a/src/lib/Recorder.ts
+++ b/src/lib/Recorder.ts
@@ -44,6 +44,8 @@ class Recorder {
 
     #pc: RTCPeerConnection | null = null
 
+    #pendingIceCandidates: RTCIceCandidateInit[] = []
+
     #stream: MediaStream | null = null
 
     #onOffer: RecorderOfferCallback | null = null
@@ -133,17 +135,31 @@ class Recorder {
     }
 
     async handleAnswer({ sdp }: { sdp: string }): Promise<void> {
-        if (this.#pc) {
-            await this.#pc.setRemoteDescription(
-                new RTCSessionDescription({ type: 'answer', sdp }),
-            )
-        }
+        const peerConnection = this.#pc
+        if (!peerConnection) return
+
+        await peerConnection.setRemoteDescription(
+            new RTCSessionDescription({ type: 'answer', sdp }),
+        )
+        if (peerConnection !== this.#pc) return
+
+        const pendingCandidates = this.#pendingIceCandidates
+        this.#pendingIceCandidates = []
+        await Promise.all(pendingCandidates.map((candidate) => (
+            peerConnection.addIceCandidate(new RTCIceCandidate(candidate))
+        )))
     }
 
     async handleIce(candidate: RTCIceCandidateInit | null): Promise<void> {
-        if (this.#pc && candidate) {
-            await this.#pc.addIceCandidate(new RTCIceCandidate(candidate))
+        const peerConnection = this.#pc
+        if (!peerConnection || !candidate) return
+
+        if (!peerConnection.remoteDescription) {
+            this.#pendingIceCandidates.push(candidate)
+            return
         }
+
+        await peerConnection.addIceCandidate(new RTCIceCandidate(candidate))
     }
 
     stopCapture(): void {
@@ -155,6 +171,7 @@ class Recorder {
         this.#stream?.getTracks().forEach((t) => t.stop())
         this.#pc?.close()
         this.#pc = null
+        this.#pendingIceCandidates = []
         this.#stream = null
     }
 

--- a/tests/src/lib/recorder.spec.ts
+++ b/tests/src/lib/recorder.spec.ts
@@ -27,12 +27,16 @@ function createMockRTCPeerConnection() {
         addTrack: vi.fn(),
         createOffer: vi.fn().mockResolvedValue({ sdp: 'mock-offer-sdp', type: 'offer' }),
         setLocalDescription: vi.fn().mockResolvedValue(undefined),
-        setRemoteDescription: vi.fn().mockResolvedValue(undefined),
+        setRemoteDescription: vi.fn(),
+        remoteDescription: null as RTCSessionDescriptionInit | null,
         addIceCandidate: vi.fn().mockResolvedValue(undefined),
         getSenders: vi.fn().mockReturnValue([mockSender]),
         close: vi.fn(),
         onicecandidate: null as ((e: { candidate: unknown }) => void) | null,
     }
+    mockPc.setRemoteDescription.mockImplementation(async (description) => {
+        mockPc.remoteDescription = description
+    })
 
     global.RTCPeerConnection = vi.fn().mockImplementation(() => mockPc) as unknown as typeof RTCPeerConnection
     return mockPc
@@ -351,16 +355,61 @@ describe('Recorder', () => {
     })
 
     describe('handleIce', () => {
-        test('should add ice candidate after startCapture', async () => {
+        test('should add ice candidate after remote answer is set', async () => {
             canvas = createMockCanvas()
             const mockPc = createMockRTCPeerConnection()
 
             const candidate = { candidate: 'mock', sdpMid: '0', sdpMLineIndex: 0 }
             const module = createRecorder()
             await module.startCapture()
+            await module.handleAnswer({ sdp: 'mock-answer-sdp' })
             await module.handleIce(candidate)
 
             expect(mockPc.addIceCandidate).toHaveBeenCalled()
+        })
+
+        test('should queue ice candidate while remote answer is being set', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            let resolveRemoteDescription!: () => void
+            mockPc.setRemoteDescription.mockImplementation((description) => new Promise<void>((resolve) => {
+                resolveRemoteDescription = () => {
+                    mockPc.remoteDescription = description
+                    resolve()
+                }
+            }))
+
+            const candidate = { candidate: 'early', sdpMid: '0', sdpMLineIndex: 0 }
+            const module = createRecorder()
+            await module.startCapture()
+            const answerPromise = module.handleAnswer({ sdp: 'mock-answer-sdp' })
+            await vi.waitFor(() => expect(mockPc.setRemoteDescription).toHaveBeenCalled())
+
+            await module.handleIce(candidate)
+            expect(mockPc.addIceCandidate).not.toHaveBeenCalled()
+
+            resolveRemoteDescription()
+            await answerPromise
+            expect(mockPc.addIceCandidate).toHaveBeenCalledWith(candidate)
+        })
+
+        test('should discard queued ice candidates when capture stops', async () => {
+            canvas = createMockCanvas()
+            const firstPc = createMockRTCPeerConnection()
+            const secondPc = createMockRTCPeerConnection()
+            global.RTCPeerConnection = vi.fn()
+                .mockImplementationOnce(() => firstPc)
+                .mockImplementationOnce(() => secondPc) as unknown as typeof RTCPeerConnection
+
+            const module = createRecorder()
+            await module.startCapture()
+            await module.handleIce({ candidate: 'stale', sdpMid: '0', sdpMLineIndex: 0 })
+            module.stopCapture()
+            await module.startCapture()
+            await module.handleAnswer({ sdp: 'fresh-answer-sdp' })
+
+            expect(firstPc.addIceCandidate).not.toHaveBeenCalled()
+            expect(secondPc.addIceCandidate).not.toHaveBeenCalled()
         })
 
         test('should do nothing when peer connection does not exist', async () => {


### PR DESCRIPTION
## Summary

- queue recorder ICE candidates received before the remote answer is installed
- flush queued candidates after `setRemoteDescription` completes
- discard queued candidates when the capture is stopped or restarted
- cover early ICE delivery and stale candidate cleanup with regression tests

## Verification

- `npm test` (95 tests)
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`
