### PR TITLE
Add QA screenshot capture

### DIFF
--- a/src/lib/Recorder.ts
+++ b/src/lib/Recorder.ts
@@ -15,6 +15,9 @@
  * along with Playgama Bridge. If not, see <https://www.gnu.org/licenses/>.
  */
 
+const SCREENSHOT_CAPTURE_FPS = 30
+const SCREENSHOT_FRAME_TIMEOUT_MS = 1000
+
 export type RecorderPriority = 'very-low' | 'low' | 'medium' | 'high'
 
 export interface RecorderStartOptions {
@@ -175,12 +178,23 @@ class Recorder {
         await peerConnection.addIceCandidate(new RTCIceCandidate(candidate))
     }
 
-    takeScreenshot({
-        type = 'image/png',
-        quality = 0.92,
-        maxWidth,
-        maxHeight,
-    }: RecorderScreenshotOptions = {}): RecorderScreenshotResult {
+    takeScreenshot(options: RecorderScreenshotOptions = {}): RecorderScreenshotResult {
+        const sourceCanvas = this.#getCanvas()
+        if (!sourceCanvas) {
+            return { success: false, reason: 'Canvas not found', data: null }
+        }
+        return this.#serializeScreenshot(
+            sourceCanvas,
+            sourceCanvas.width,
+            sourceCanvas.height,
+            options,
+            sourceCanvas,
+        )
+    }
+
+    async takeScreenshotFromSurface(
+        options: RecorderScreenshotOptions = {},
+    ): Promise<RecorderScreenshotResult> {
         const sourceCanvas = this.#getCanvas()
         if (!sourceCanvas) {
             return { success: false, reason: 'Canvas not found', data: null }
@@ -188,9 +202,83 @@ class Recorder {
         if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
             return { success: false, reason: 'Canvas has no drawable area', data: null }
         }
+        if (typeof sourceCanvas.captureStream !== 'function') {
+            return this.takeScreenshot(options)
+        }
+
+        let stream: MediaStream | null = null
+        let video: HTMLVideoElement | null = null
+        try {
+            stream = sourceCanvas.captureStream(SCREENSHOT_CAPTURE_FPS)
+            const track = stream.getVideoTracks()[0]
+            if (!track) {
+                return { success: false, reason: 'Canvas capture has no video track', data: null }
+            }
+
+            video = document.createElement('video')
+            video.srcObject = stream
+            video.muted = true
+            video.playsInline = true
+            await this.#waitForVideoFrame(video, track)
+            return this.#serializeScreenshot(
+                video,
+                video.videoWidth,
+                video.videoHeight,
+                options,
+            )
+        } catch (error) {
+            return {
+                success: false,
+                reason: error && typeof error === 'object' && 'message' in error
+                    ? String(error.message)
+                    : 'Screenshot capture failed',
+                data: null,
+            }
+        } finally {
+            video?.pause()
+            if (video) video.srcObject = null
+            stream?.getTracks().forEach((track) => track.stop())
+        }
+    }
+
+    stopCapture(): void {
+        this.#captureGeneration += 1
+        this.#clearCaptureResources()
+    }
+
+    #clearCaptureResources(): void {
+        this.#stream?.getTracks().forEach((t) => t.stop())
+        this.#pc?.close()
+        this.#pc = null
+        this.#pendingIceCandidates = []
+        this.#stream = null
+    }
+
+    #serializeScreenshot(
+        source: CanvasImageSource,
+        sourceWidth: number,
+        sourceHeight: number,
+        {
+            type = 'image/png',
+            quality = 0.92,
+            maxWidth,
+            maxHeight,
+        }: RecorderScreenshotOptions = {},
+        reusableCanvas: HTMLCanvasElement | null = null,
+    ): RecorderScreenshotResult {
+        if (sourceWidth === 0 || sourceHeight === 0) {
+            return { success: false, reason: 'Screenshot source has no drawable area', data: null }
+        }
 
         try {
-            const canvas = this.#fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight)
+            const canvas = this.#fitScreenshotSource(
+                source,
+                sourceWidth,
+                sourceHeight,
+                maxWidth,
+                maxHeight,
+                reusableCanvas,
+            )
             if (!canvas) {
                 return { success: false, reason: 'Canvas context is not available', data: null }
             }
@@ -213,52 +301,35 @@ class Recorder {
         }
     }
 
-    async takeScreenshotAfterPaint(
-        options: RecorderScreenshotOptions = {},
-    ): Promise<RecorderScreenshotResult> {
-        await this.#waitForPaint()
-        return this.takeScreenshot(options)
-    }
-
-    stopCapture(): void {
-        this.#captureGeneration += 1
-        this.#clearCaptureResources()
-    }
-
-    #clearCaptureResources(): void {
-        this.#stream?.getTracks().forEach((t) => t.stop())
-        this.#pc?.close()
-        this.#pc = null
-        this.#pendingIceCandidates = []
-        this.#stream = null
-    }
-
-    #fitScreenshotCanvas(
-        sourceCanvas: HTMLCanvasElement,
+    #fitScreenshotSource(
+        source: CanvasImageSource,
+        sourceWidth: number,
+        sourceHeight: number,
         maxWidth: number | undefined,
         maxHeight: number | undefined,
+        reusableCanvas: HTMLCanvasElement | null,
     ): HTMLCanvasElement | null {
         const widthLimit = typeof maxWidth === 'number'
             && Number.isFinite(maxWidth) && maxWidth > 0
             ? maxWidth
-            : sourceCanvas.width
+            : sourceWidth
         const heightLimit = typeof maxHeight === 'number'
             && Number.isFinite(maxHeight) && maxHeight > 0
             ? maxHeight
-            : sourceCanvas.height
+            : sourceHeight
         const scale = Math.min(
             1,
-            widthLimit / sourceCanvas.width,
-            heightLimit / sourceCanvas.height,
+            widthLimit / sourceWidth,
+            heightLimit / sourceHeight,
         )
-        if (scale === 1) return sourceCanvas
+        if (scale === 1 && reusableCanvas) return reusableCanvas
 
         const canvas = document.createElement('canvas')
-        canvas.width = Math.max(1, Math.round(sourceCanvas.width * scale))
-        canvas.height = Math.max(1, Math.round(sourceCanvas.height * scale))
+        canvas.width = Math.max(1, Math.round(sourceWidth * scale))
+        canvas.height = Math.max(1, Math.round(sourceHeight * scale))
         const context = canvas.getContext('2d')
         if (!context) return null
-        context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height)
+        context.drawImage(source, 0, 0, canvas.width, canvas.height)
         return canvas
     }
 
@@ -325,22 +396,47 @@ class Recorder {
         return typeof HTMLCanvasElement.prototype.captureStream === 'function'
     }
 
-    #waitForPaint(): Promise<void> {
-        if (typeof requestAnimationFrame !== 'function') return Promise.resolve()
-
-        return new Promise((resolve) => {
-            let completed = false
-            let frameId = 0
-            let timeoutId: ReturnType<typeof setTimeout>
-            const finish = (): void => {
-                if (completed) return
-                completed = true
-                clearTimeout(timeoutId)
-                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId)
-                resolve()
+    #waitForVideoFrame(video: HTMLVideoElement, track: MediaStreamTrack): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const cleanups: Array<() => void> = []
+            let frameCallbackId: number | null = null
+            let settled = false
+            const settle = (complete: () => void): void => {
+                if (settled) return
+                settled = true
+                cleanups.forEach((cleanup) => cleanup())
+                complete()
             }
-            timeoutId = setTimeout(finish, 100)
-            frameId = requestAnimationFrame(finish)
+            const onEnded = (): void => settle(
+                () => reject(new Error('Canvas capture ended before its first frame')),
+            )
+            const onLoadedData = (): void => settle(resolve)
+            const timeoutId = setTimeout(() => settle(
+                () => reject(new Error('Canvas capture produced no video frames')),
+            ), SCREENSHOT_FRAME_TIMEOUT_MS)
+            cleanups.push(() => clearTimeout(timeoutId))
+            track.addEventListener('ended', onEnded, { once: true })
+            cleanups.push(() => track.removeEventListener('ended', onEnded))
+
+            if (typeof video.requestVideoFrameCallback === 'function') {
+                frameCallbackId = video.requestVideoFrameCallback(() => settle(resolve))
+                cleanups.push(() => {
+                    if (frameCallbackId !== null
+                        && typeof video.cancelVideoFrameCallback === 'function') {
+                        video.cancelVideoFrameCallback(frameCallbackId)
+                    }
+                })
+            } else {
+                video.addEventListener('loadeddata', onLoadedData, { once: true })
+                cleanups.push(() => video.removeEventListener('loadeddata', onLoadedData))
+            }
+
+            Promise.resolve(video.play()).then(() => {
+                if (typeof video.requestVideoFrameCallback !== 'function'
+                    && video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+                    settle(resolve)
+                }
+            }).catch((error) => settle(() => reject(error)))
         })
     }
 }

--- a/src/lib/Recorder.ts
+++ b/src/lib/Recorder.ts
@@ -34,6 +34,19 @@ export interface RecorderAvailability {
     reason: string | null
 }
 
+export interface RecorderScreenshotOptions {
+    type?: string
+    quality?: number
+    maxWidth?: number
+    maxHeight?: number
+}
+
+export interface RecorderScreenshotResult {
+    success: boolean
+    reason: string | null
+    data: string | null
+}
+
 export type RecorderOfferCallback = (sdp: string | undefined) => void
 export type RecorderIceCandidateCallback = (candidate: RTCIceCandidateInit) => void
 export type RecorderStartedCallback = () => void
@@ -162,6 +175,51 @@ class Recorder {
         await peerConnection.addIceCandidate(new RTCIceCandidate(candidate))
     }
 
+    takeScreenshot({
+        type = 'image/png',
+        quality = 0.92,
+        maxWidth,
+        maxHeight,
+    }: RecorderScreenshotOptions = {}): RecorderScreenshotResult {
+        const sourceCanvas = this.#getCanvas()
+        if (!sourceCanvas) {
+            return { success: false, reason: 'Canvas not found', data: null }
+        }
+        if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
+            return { success: false, reason: 'Canvas has no drawable area', data: null }
+        }
+
+        try {
+            const canvas = this.#fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight)
+            if (!canvas) {
+                return { success: false, reason: 'Canvas context is not available', data: null }
+            }
+            const normalizedQuality = Number.isFinite(quality)
+                ? Math.min(1, Math.max(0, quality))
+                : 0.92
+            const data = canvas.toDataURL(type, normalizedQuality)
+            if (data === 'data:,') {
+                return { success: false, reason: 'Canvas produced an empty screenshot', data: null }
+            }
+            return { success: true, reason: null, data }
+        } catch (error) {
+            return {
+                success: false,
+                reason: error && typeof error === 'object' && 'message' in error
+                    ? String(error.message)
+                    : 'Screenshot capture failed',
+                data: null,
+            }
+        }
+    }
+
+    async takeScreenshotAfterPaint(
+        options: RecorderScreenshotOptions = {},
+    ): Promise<RecorderScreenshotResult> {
+        await this.#waitForPaint()
+        return this.takeScreenshot(options)
+    }
+
     stopCapture(): void {
         this.#captureGeneration += 1
         this.#clearCaptureResources()
@@ -173,6 +231,35 @@ class Recorder {
         this.#pc = null
         this.#pendingIceCandidates = []
         this.#stream = null
+    }
+
+    #fitScreenshotCanvas(
+        sourceCanvas: HTMLCanvasElement,
+        maxWidth: number | undefined,
+        maxHeight: number | undefined,
+    ): HTMLCanvasElement | null {
+        const widthLimit = typeof maxWidth === 'number'
+            && Number.isFinite(maxWidth) && maxWidth > 0
+            ? maxWidth
+            : sourceCanvas.width
+        const heightLimit = typeof maxHeight === 'number'
+            && Number.isFinite(maxHeight) && maxHeight > 0
+            ? maxHeight
+            : sourceCanvas.height
+        const scale = Math.min(
+            1,
+            widthLimit / sourceCanvas.width,
+            heightLimit / sourceCanvas.height,
+        )
+        if (scale === 1) return sourceCanvas
+
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.max(1, Math.round(sourceCanvas.width * scale))
+        canvas.height = Math.max(1, Math.round(sourceCanvas.height * scale))
+        const context = canvas.getContext('2d')
+        if (!context) return null
+        context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height)
+        return canvas
     }
 
     #applyEncodingParams(
@@ -236,6 +323,25 @@ class Recorder {
 
     #isCaptureStreamSupported(): boolean {
         return typeof HTMLCanvasElement.prototype.captureStream === 'function'
+    }
+
+    #waitForPaint(): Promise<void> {
+        if (typeof requestAnimationFrame !== 'function') return Promise.resolve()
+
+        return new Promise((resolve) => {
+            let completed = false
+            let frameId = 0
+            let timeoutId: ReturnType<typeof setTimeout>
+            const finish = (): void => {
+                if (completed) return
+                completed = true
+                clearTimeout(timeoutId)
+                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId)
+                resolve()
+            }
+            timeoutId = setTimeout(finish, 100)
+            frameId = requestAnimationFrame(finish)
+        })
     }
 }
 

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -1103,7 +1103,7 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 this.#recorder.handleIce(data.options as RTCIceCandidateInit)
                 break
             case RECORDER_ACTION.TAKE_SCREENSHOT:
-                this.#recorder.takeScreenshotAfterPaint(data.options).then((result) => {
+                this.#recorder.takeScreenshotFromSurface(data.options).then((result) => {
                     this.#sendMessage({
                         type: MODULE_NAME_QA.RECORDER,
                         action: RECORDER_ACTION.SCREENSHOT_RESULT,

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -88,6 +88,8 @@ const RECORDER_ACTION = {
     RTC_ICE: 'rtc_ice',
     CAPTURE_STARTED: 'capture_started',
     CAPTURE_ERROR: 'capture_error',
+    TAKE_SCREENSHOT: 'take_screenshot',
+    SCREENSHOT_RESULT: 'screenshot_result',
 } as const
 
 const INTERSTITIAL_STATUS = {
@@ -1099,6 +1101,16 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 break
             case RECORDER_ACTION.RTC_ICE:
                 this.#recorder.handleIce(data.options as RTCIceCandidateInit)
+                break
+            case RECORDER_ACTION.TAKE_SCREENSHOT:
+                this.#recorder.takeScreenshotAfterPaint(data.options).then((result) => {
+                    this.#sendMessage({
+                        type: MODULE_NAME_QA.RECORDER,
+                        action: RECORDER_ACTION.SCREENSHOT_RESULT,
+                        id: data.id,
+                        payload: result as unknown as Record<string, unknown>,
+                    })
+                })
                 break
             default:
                 break

--- a/tests/src/lib/recorder.spec.ts
+++ b/tests/src/lib/recorder.spec.ts
@@ -25,6 +25,51 @@ function createMockCanvas(options: {
     return canvas
 }
 
+function mockCapturedScreenshotFrame(
+    sourceCanvas: HTMLCanvasElement,
+    data = 'data:image/jpeg;base64,capturedFrame',
+) {
+    const track = {
+        kind: 'video',
+        readyState: 'live',
+        stop: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }
+    const stream = {
+        getVideoTracks: () => [track],
+        getTracks: () => [track],
+    }
+    sourceCanvas.captureStream = vi.fn().mockReturnValue(stream)
+
+    const video = document.createElement('video')
+    Object.defineProperties(video, {
+        videoWidth: { value: sourceCanvas.width },
+        videoHeight: { value: sourceCanvas.height },
+        requestVideoFrameCallback: {
+            value: vi.fn((callback: VideoFrameRequestCallback) => {
+                queueMicrotask(() => callback(0, {} as VideoFrameCallbackMetadata))
+                return 1
+            }),
+        },
+        cancelVideoFrameCallback: { value: vi.fn() },
+    })
+    vi.spyOn(video, 'play').mockResolvedValue(undefined)
+    vi.spyOn(video, 'pause').mockImplementation(() => {})
+
+    const outputCanvas = document.createElement('canvas')
+    const drawImage = vi.fn()
+    vi.spyOn(outputCanvas, 'getContext').mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(outputCanvas, 'toDataURL').mockReturnValue(data)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        if (tagName === 'video') return video
+        if (tagName === 'canvas') return outputCanvas
+        throw new Error(`Unexpected element: ${tagName}`)
+    })
+
+    return { stream, track, video, outputCanvas, drawImage }
+}
+
 function createMockRTCPeerConnection() {
     const setParameters = vi.fn().mockResolvedValue(undefined)
     const mockSender = {
@@ -355,26 +400,50 @@ describe('Recorder', () => {
             })
         })
 
-        test('should wait for paint and return base64 data', async () => {
-            canvas = createMockCanvas({ toDataURL: 'data:image/jpeg;base64,screenshot' })
-            vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-                callback(0)
-                return 1
-            })
-            vi.stubGlobal('cancelAnimationFrame', vi.fn())
+        test('should capture the painted surface without reading the source drawing buffer', async () => {
+            canvas = createMockCanvas()
+            const sourceToDataURL = canvas.toDataURL
+            const { track, video, outputCanvas, drawImage } = mockCapturedScreenshotFrame(canvas)
 
             const module = createRecorder()
-            const result = await module.takeScreenshotAfterPaint({
+            const result = await module.takeScreenshotFromSurface({
                 type: 'image/jpeg',
-                quality: 0.8,
+                quality: 0.85,
             })
 
-            expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.8)
+            expect(sourceToDataURL).not.toHaveBeenCalled()
+            expect(canvas.captureStream).toHaveBeenCalledWith(30)
+            expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 1280, 720)
+            expect(outputCanvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.85)
+            expect(track.stop).toHaveBeenCalledOnce()
             expect(result).toEqual({
                 success: true,
                 reason: null,
-                data: 'data:image/jpeg;base64,screenshot',
+                data: 'data:image/jpeg;base64,capturedFrame',
             })
+        })
+
+        test('should stop only the screenshot track while recording capture is active', async () => {
+            canvas = createMockCanvas()
+            const recordingTrack = { kind: 'video', stop: vi.fn() }
+            const recordingStream = {
+                getVideoTracks: () => [recordingTrack],
+                getTracks: () => [recordingTrack],
+            }
+            const { stream, track } = mockCapturedScreenshotFrame(canvas)
+            vi.mocked(canvas.captureStream)
+                .mockReset()
+                .mockReturnValueOnce(recordingStream as unknown as MediaStream)
+                .mockReturnValueOnce(stream as unknown as MediaStream)
+            const peerConnection = createMockRTCPeerConnection()
+            const module = createRecorder()
+
+            await module.startCapture()
+            await module.takeScreenshotFromSurface()
+
+            expect(recordingTrack.stop).not.toHaveBeenCalled()
+            expect(track.stop).toHaveBeenCalledOnce()
+            expect(peerConnection.close).not.toHaveBeenCalled()
         })
 
         test('should return an error when canvas serialization fails', () => {

--- a/tests/src/lib/recorder.spec.ts
+++ b/tests/src/lib/recorder.spec.ts
@@ -7,8 +7,17 @@ function createRecorder() {
     return new Recorder()
 }
 
-function createMockCanvas() {
+function createMockCanvas(options: {
+    width?: number
+    height?: number
+    toDataURL?: string
+} = {}) {
     const canvas = document.createElement('canvas')
+    canvas.width = options.width ?? 1280
+    canvas.height = options.height ?? 720
+    vi.spyOn(canvas, 'toDataURL').mockReturnValue(
+        options.toDataURL || 'data:image/png;base64,mockData',
+    )
     canvas.captureStream = vi.fn().mockReturnValue({
         getTracks: () => [{ stop: vi.fn() }],
     })
@@ -55,6 +64,7 @@ describe('Recorder', () => {
     })
 
     afterEach(() => {
+        vi.unstubAllGlobals()
         if (canvas) {
             canvas.remove()
             canvas = null
@@ -331,6 +341,75 @@ describe('Recorder', () => {
             expect(onIceCandidate).toHaveBeenCalledWith({ candidate: 'fresh-candidate' })
             expect(onStarted).toHaveBeenCalledOnce()
             expect(firstPc.setLocalDescription).not.toHaveBeenCalled()
+        })
+    })
+
+    describe('takeScreenshot', () => {
+        test('should return an error when canvas is not found', () => {
+            const module = createRecorder()
+
+            expect(module.takeScreenshot()).toEqual({
+                success: false,
+                reason: 'Canvas not found',
+                data: null,
+            })
+        })
+
+        test('should wait for paint and return base64 data', async () => {
+            canvas = createMockCanvas({ toDataURL: 'data:image/jpeg;base64,screenshot' })
+            vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+                callback(0)
+                return 1
+            })
+            vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+            const module = createRecorder()
+            const result = await module.takeScreenshotAfterPaint({
+                type: 'image/jpeg',
+                quality: 0.8,
+            })
+
+            expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.8)
+            expect(result).toEqual({
+                success: true,
+                reason: null,
+                data: 'data:image/jpeg;base64,screenshot',
+            })
+        })
+
+        test('should return an error when canvas serialization fails', () => {
+            canvas = createMockCanvas()
+            vi.spyOn(canvas, 'toDataURL').mockImplementation(() => {
+                throw new DOMException('Canvas is tainted', 'SecurityError')
+            })
+
+            const module = createRecorder()
+
+            expect(module.takeScreenshot()).toEqual({
+                success: false,
+                reason: 'Canvas is tainted',
+                data: null,
+            })
+        })
+
+        test('should downscale oversized screenshots', () => {
+            canvas = createMockCanvas({ width: 3840, height: 2160 })
+            const resizedCanvas = document.createElement('canvas')
+            const drawImage = vi.fn()
+            vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+                if (tagName === 'canvas') return resizedCanvas
+                throw new Error(`Unexpected element: ${tagName}`)
+            })
+            vi.spyOn(resizedCanvas, 'getContext').mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D)
+            vi.spyOn(resizedCanvas, 'toDataURL').mockReturnValue('data:image/png;base64,resized')
+
+            const module = createRecorder()
+            const result = module.takeScreenshot({ maxWidth: 1920, maxHeight: 1080 })
+
+            expect(resizedCanvas.width).toBe(1920)
+            expect(resizedCanvas.height).toBe(1080)
+            expect(drawImage).toHaveBeenCalledWith(canvas, 0, 0, 1920, 1080)
+            expect(result.data).toBe('data:image/png;base64,resized')
         })
     })
 


### PR DESCRIPTION
## Summary

- add the QA screenshot request and response flow with request IDs
- capture screenshots from the painted canvas surface through a short-lived local media track
- support WebGL canvases without relying on drawing-buffer preservation
- resize and encode screenshots in the bridge and return structured failures
- stop only the temporary screenshot track when recording is active

## Validation

- npm test (100 tests)
- npm run lint
- npx tsc --noEmit
- npm run build
- Chromium WebGL smoke with preserveDrawingBuffer disabled
