### PR TITLE
Harden QA screenshot capture

### DIFF
--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -15,6 +15,9 @@
  * along with Playgama Bridge. If not, see <https://www.gnu.org/licenses/>.
  */
 
+const SCREENSHOT_CAPTURE_FPS = 30
+const SCREENSHOT_FRAME_TIMEOUT_MS = 1000
+
 class RecorderModule {
     #captureGeneration = 0
 
@@ -174,12 +177,22 @@ class RecorderModule {
      * @param {number} [options.maxHeight] - Maximum screenshot height
      * @returns {{ success: boolean, reason: string | null, data: string | null }}
      */
-    takeScreenshot({
-        type = 'image/png',
-        quality = 0.92,
-        maxWidth,
-        maxHeight,
-    } = {}) {
+    takeScreenshot(options = {}) {
+        const sourceCanvas = this.#getCanvas()
+        if (!sourceCanvas) {
+            return { success: false, reason: 'Canvas not found', data: null }
+        }
+        return this.#serializeScreenshot(
+            sourceCanvas,
+            sourceCanvas.width,
+            sourceCanvas.height,
+            options,
+            sourceCanvas,
+        )
+    }
+
+    /** @returns {Promise<{ success: boolean, reason: string | null, data: string | null }>} */
+    async takeScreenshotFromSurface(options = {}) {
         const sourceCanvas = this.#getCanvas()
         if (!sourceCanvas) {
             return { success: false, reason: 'Canvas not found', data: null }
@@ -187,9 +200,78 @@ class RecorderModule {
         if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
             return { success: false, reason: 'Canvas has no drawable area', data: null }
         }
+        if (typeof sourceCanvas.captureStream !== 'function') {
+            return this.takeScreenshot(options)
+        }
+
+        let stream = null
+        let video = null
+        try {
+            stream = sourceCanvas.captureStream(SCREENSHOT_CAPTURE_FPS)
+            const track = stream.getVideoTracks()[0]
+            if (!track) {
+                return { success: false, reason: 'Canvas capture has no video track', data: null }
+            }
+
+            video = document.createElement('video')
+            video.srcObject = stream
+            video.muted = true
+            video.playsInline = true
+            await this.#waitForVideoFrame(video, track)
+            return this.#serializeScreenshot(
+                video,
+                video.videoWidth,
+                video.videoHeight,
+                options,
+            )
+        } catch (error) {
+            return {
+                success: false,
+                reason: error && typeof error === 'object' && 'message' in error
+                    ? String(error.message)
+                    : 'Screenshot capture failed',
+                data: null,
+            }
+        } finally {
+            video?.pause()
+            if (video) video.srcObject = null
+            stream?.getTracks().forEach((track) => track.stop())
+        }
+    }
+
+    /** Stops the capture, closes the peer connection and releases all tracks. */
+    stopCapture() {
+        this.#captureGeneration += 1
+        this.#clearCaptureResources()
+    }
+
+    #clearCaptureResources() {
+        this.#stream?.getTracks().forEach((t) => t.stop())
+        this.#pc?.close()
+        this.#pc = null
+        this.#pendingIceCandidates = []
+        this.#stream = null
+    }
+
+    #serializeScreenshot(source, sourceWidth, sourceHeight, {
+        type = 'image/png',
+        quality = 0.92,
+        maxWidth,
+        maxHeight,
+    } = {}, reusableCanvas = null) {
+        if (sourceWidth === 0 || sourceHeight === 0) {
+            return { success: false, reason: 'Screenshot source has no drawable area', data: null }
+        }
 
         try {
-            const canvas = this.#fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight)
+            const canvas = this.#fitScreenshotSource(
+                source,
+                sourceWidth,
+                sourceHeight,
+                maxWidth,
+                maxHeight,
+                reusableCanvas,
+            )
             if (!canvas) {
                 return { success: false, reason: 'Canvas context is not available', data: null }
             }
@@ -212,52 +294,28 @@ class RecorderModule {
         }
     }
 
-    /**
-     * Waits for the next paint before taking a screenshot.
-     * @param {Object} [options] - Screenshot options passed to takeScreenshot()
-     * @returns {Promise<{ success: boolean, reason: string | null, data: string | null }>}
-     */
-    async takeScreenshotAfterPaint(options = {}) {
-        await this.#waitForPaint()
-        return this.takeScreenshot(options)
-    }
-
-    /** Stops the capture, closes the peer connection and releases all tracks. */
-    stopCapture() {
-        this.#captureGeneration += 1
-        this.#clearCaptureResources()
-    }
-
-    #clearCaptureResources() {
-        this.#stream?.getTracks().forEach((t) => t.stop())
-        this.#pc?.close()
-        this.#pc = null
-        this.#pendingIceCandidates = []
-        this.#stream = null
-    }
-
-    #fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight) {
+    #fitScreenshotSource(source, sourceWidth, sourceHeight, maxWidth, maxHeight, reusableCanvas) {
         const widthLimit = typeof maxWidth === 'number'
             && Number.isFinite(maxWidth) && maxWidth > 0
             ? maxWidth
-            : sourceCanvas.width
+            : sourceWidth
         const heightLimit = typeof maxHeight === 'number'
             && Number.isFinite(maxHeight) && maxHeight > 0
             ? maxHeight
-            : sourceCanvas.height
+            : sourceHeight
         const scale = Math.min(
             1,
-            widthLimit / sourceCanvas.width,
-            heightLimit / sourceCanvas.height,
+            widthLimit / sourceWidth,
+            heightLimit / sourceHeight,
         )
-        if (scale === 1) return sourceCanvas
+        if (scale === 1 && reusableCanvas) return reusableCanvas
 
         const canvas = document.createElement('canvas')
-        canvas.width = Math.max(1, Math.round(sourceCanvas.width * scale))
-        canvas.height = Math.max(1, Math.round(sourceCanvas.height * scale))
+        canvas.width = Math.max(1, Math.round(sourceWidth * scale))
+        canvas.height = Math.max(1, Math.round(sourceHeight * scale))
         const context = canvas.getContext('2d')
         if (!context) return null
-        context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height)
+        context.drawImage(source, 0, 0, canvas.width, canvas.height)
         return canvas
     }
 
@@ -317,22 +375,47 @@ class RecorderModule {
         return typeof HTMLCanvasElement.prototype.captureStream === 'function'
     }
 
-    #waitForPaint() {
-        if (typeof requestAnimationFrame !== 'function') return Promise.resolve()
-
-        return new Promise((resolve) => {
-            let completed = false
-            let frameId = 0
-            let timeoutId
-            const finish = () => {
-                if (completed) return
-                completed = true
-                clearTimeout(timeoutId)
-                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId)
-                resolve()
+    #waitForVideoFrame(video, track) {
+        return new Promise((resolve, reject) => {
+            const cleanups = []
+            let frameCallbackId = null
+            let settled = false
+            const settle = (complete) => {
+                if (settled) return
+                settled = true
+                cleanups.forEach((cleanup) => cleanup())
+                complete()
             }
-            timeoutId = setTimeout(finish, 100)
-            frameId = requestAnimationFrame(finish)
+            const onEnded = () => settle(
+                () => reject(new Error('Canvas capture ended before its first frame')),
+            )
+            const onLoadedData = () => settle(resolve)
+            const timeoutId = setTimeout(() => settle(
+                () => reject(new Error('Canvas capture produced no video frames')),
+            ), SCREENSHOT_FRAME_TIMEOUT_MS)
+            cleanups.push(() => clearTimeout(timeoutId))
+            track.addEventListener('ended', onEnded, { once: true })
+            cleanups.push(() => track.removeEventListener('ended', onEnded))
+
+            if (typeof video.requestVideoFrameCallback === 'function') {
+                frameCallbackId = video.requestVideoFrameCallback(() => settle(resolve))
+                cleanups.push(() => {
+                    if (frameCallbackId !== null
+                        && typeof video.cancelVideoFrameCallback === 'function') {
+                        video.cancelVideoFrameCallback(frameCallbackId)
+                    }
+                })
+            } else {
+                video.addEventListener('loadeddata', onLoadedData, { once: true })
+                cleanups.push(() => video.removeEventListener('loadeddata', onLoadedData))
+            }
+
+            Promise.resolve(video.play()).then(() => {
+                if (typeof video.requestVideoFrameCallback !== 'function'
+                    && video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+                    settle(resolve)
+                }
+            }).catch((error) => settle(() => reject(error)))
         })
     }
 }

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -170,15 +170,56 @@ class RecorderModule {
      * @param {Object} [options]
      * @param {string} [options.type='image/png'] - Image MIME type
      * @param {number} [options.quality=0.92] - Image quality (0–1)
+     * @param {number} [options.maxWidth] - Maximum screenshot width
+     * @param {number} [options.maxHeight] - Maximum screenshot height
      * @returns {{ success: boolean, reason: string | null, data: string | null }}
      */
-    takeScreenshot({ type = 'image/png', quality = 0.92 } = {}) {
-        const canvas = this.#getCanvas()
-        if (!canvas) {
+    takeScreenshot({
+        type = 'image/png',
+        quality = 0.92,
+        maxWidth,
+        maxHeight,
+    } = {}) {
+        const sourceCanvas = this.#getCanvas()
+        if (!sourceCanvas) {
             return { success: false, reason: 'Canvas not found', data: null }
         }
-        const data = canvas.toDataURL(type, quality)
-        return { success: true, reason: null, data }
+        if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
+            return { success: false, reason: 'Canvas has no drawable area', data: null }
+        }
+
+        try {
+            const canvas = this.#fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight)
+            if (!canvas) {
+                return { success: false, reason: 'Canvas context is not available', data: null }
+            }
+            const normalizedQuality = Number.isFinite(quality)
+                ? Math.min(1, Math.max(0, quality))
+                : 0.92
+            const data = canvas.toDataURL(type, normalizedQuality)
+            if (data === 'data:,') {
+                return { success: false, reason: 'Canvas produced an empty screenshot', data: null }
+            }
+            return { success: true, reason: null, data }
+        } catch (error) {
+            return {
+                success: false,
+                reason: error && typeof error === 'object' && 'message' in error
+                    ? String(error.message)
+                    : 'Screenshot capture failed',
+                data: null,
+            }
+        }
+    }
+
+    /**
+     * Waits for the next paint before taking a screenshot.
+     * @param {Object} [options] - Screenshot options passed to takeScreenshot()
+     * @returns {Promise<{ success: boolean, reason: string | null, data: string | null }>}
+     */
+    async takeScreenshotAfterPaint(options = {}) {
+        await this.#waitForPaint()
+        return this.takeScreenshot(options)
     }
 
     /** Stops the capture, closes the peer connection and releases all tracks. */
@@ -193,6 +234,31 @@ class RecorderModule {
         this.#pc = null
         this.#pendingIceCandidates = []
         this.#stream = null
+    }
+
+    #fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight) {
+        const widthLimit = typeof maxWidth === 'number'
+            && Number.isFinite(maxWidth) && maxWidth > 0
+            ? maxWidth
+            : sourceCanvas.width
+        const heightLimit = typeof maxHeight === 'number'
+            && Number.isFinite(maxHeight) && maxHeight > 0
+            ? maxHeight
+            : sourceCanvas.height
+        const scale = Math.min(
+            1,
+            widthLimit / sourceCanvas.width,
+            heightLimit / sourceCanvas.height,
+        )
+        if (scale === 1) return sourceCanvas
+
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.max(1, Math.round(sourceCanvas.width * scale))
+        canvas.height = Math.max(1, Math.round(sourceCanvas.height * scale))
+        const context = canvas.getContext('2d')
+        if (!context) return null
+        context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height)
+        return canvas
     }
 
     #applyEncodingParams(peerConnection, {
@@ -249,6 +315,25 @@ class RecorderModule {
 
     #isCaptureStreamSupported() {
         return typeof HTMLCanvasElement.prototype.captureStream === 'function'
+    }
+
+    #waitForPaint() {
+        if (typeof requestAnimationFrame !== 'function') return Promise.resolve()
+
+        return new Promise((resolve) => {
+            let completed = false
+            let frameId = 0
+            let timeoutId
+            const finish = () => {
+                if (completed) return
+                completed = true
+                clearTimeout(timeoutId)
+                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId)
+                resolve()
+            }
+            timeoutId = setTimeout(finish, 100)
+            frameId = requestAnimationFrame(finish)
+        })
     }
 }
 

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -1221,11 +1221,13 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 recorderModule.handleIce(data.options)
                 break
             case RECORDER_ACTION.TAKE_SCREENSHOT: {
-                const result = recorderModule.takeScreenshot(data.options || {})
-                this.#sendMessage({
-                    type: MODULE_NAME.RECORDER,
-                    action: RECORDER_ACTION.SCREENSHOT_RESULT,
-                    payload: result,
+                recorderModule.takeScreenshotAfterPaint(data.options || {}).then((result) => {
+                    this.#sendMessage({
+                        type: MODULE_NAME.RECORDER,
+                        action: RECORDER_ACTION.SCREENSHOT_RESULT,
+                        id: data.id,
+                        payload: result,
+                    })
                 })
                 break
             }

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -1221,7 +1221,7 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 recorderModule.handleIce(data.options)
                 break
             case RECORDER_ACTION.TAKE_SCREENSHOT: {
-                recorderModule.takeScreenshotAfterPaint(data.options || {}).then((result) => {
+                recorderModule.takeScreenshotFromSurface(data.options || {}).then((result) => {
                     this.#sendMessage({
                         type: MODULE_NAME.RECORDER,
                         action: RECORDER_ACTION.SCREENSHOT_RESULT,

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -21,6 +21,51 @@ function createMockCanvas(options: {
     return canvas
 }
 
+function mockCapturedScreenshotFrame(
+    sourceCanvas: HTMLCanvasElement,
+    data = 'data:image/jpeg;base64,capturedFrame',
+) {
+    const track = {
+        kind: 'video',
+        readyState: 'live',
+        stop: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }
+    const stream = {
+        getVideoTracks: () => [track],
+        getTracks: () => [track],
+    }
+    sourceCanvas.captureStream = vi.fn().mockReturnValue(stream)
+
+    const video = document.createElement('video')
+    Object.defineProperties(video, {
+        videoWidth: { value: sourceCanvas.width },
+        videoHeight: { value: sourceCanvas.height },
+        requestVideoFrameCallback: {
+            value: vi.fn((callback: VideoFrameRequestCallback) => {
+                queueMicrotask(() => callback(0, {} as VideoFrameCallbackMetadata))
+                return 1
+            }),
+        },
+        cancelVideoFrameCallback: { value: vi.fn() },
+    })
+    vi.spyOn(video, 'play').mockResolvedValue(undefined)
+    vi.spyOn(video, 'pause').mockImplementation(() => {})
+
+    const outputCanvas = document.createElement('canvas')
+    const drawImage = vi.fn()
+    vi.spyOn(outputCanvas, 'getContext').mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(outputCanvas, 'toDataURL').mockReturnValue(data)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        if (tagName === 'video') return video
+        if (tagName === 'canvas') return outputCanvas
+        throw new Error(`Unexpected element: ${tagName}`)
+    })
+
+    return { stream, track, video, outputCanvas, drawImage }
+}
+
 function createMockRTCPeerConnection() {
     const setParameters = vi.fn().mockResolvedValue(undefined)
     const mockSender = {
@@ -441,22 +486,50 @@ describe('RecorderModule', () => {
             expect(result).toEqual({ success: false, reason: 'Canvas not found', data: null })
         })
 
-        test('should wait for paint and return base64 data from canvas', async () => {
-            canvas = createMockCanvas({ toDataURL: 'data:image/png;base64,screenshotData' })
-            vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-                callback(0)
-                return 1
-            })
-            vi.stubGlobal('cancelAnimationFrame', vi.fn())
+        test('should capture the painted surface without reading the source drawing buffer', async () => {
+            canvas = createMockCanvas()
+            const sourceToDataURL = canvas.toDataURL
+            const { track, video, outputCanvas, drawImage } = mockCapturedScreenshotFrame(canvas)
 
             const module = createRecorderModule()
-            const result = await module.takeScreenshotAfterPaint()
+            const result = await module.takeScreenshotFromSurface({
+                type: 'image/jpeg',
+                quality: 0.85,
+            })
 
+            expect(sourceToDataURL).not.toHaveBeenCalled()
+            expect(canvas.captureStream).toHaveBeenCalledWith(30)
+            expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 1280, 720)
+            expect(outputCanvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.85)
+            expect(track.stop).toHaveBeenCalledOnce()
             expect(result).toEqual({
                 success: true,
                 reason: null,
-                data: 'data:image/png;base64,screenshotData',
+                data: 'data:image/jpeg;base64,capturedFrame',
             })
+        })
+
+        test('should stop only the screenshot track while recording capture is active', async () => {
+            canvas = createMockCanvas()
+            const recordingTrack = { kind: 'video', stop: vi.fn() }
+            const recordingStream = {
+                getVideoTracks: () => [recordingTrack],
+                getTracks: () => [recordingTrack],
+            }
+            const { stream, track } = mockCapturedScreenshotFrame(canvas)
+            vi.mocked(canvas.captureStream)
+                .mockReset()
+                .mockReturnValueOnce(recordingStream as unknown as MediaStream)
+                .mockReturnValueOnce(stream as unknown as MediaStream)
+            const peerConnection = createMockRTCPeerConnection()
+            const module = createRecorderModule()
+
+            await module.startCapture()
+            await module.takeScreenshotFromSurface()
+
+            expect(recordingTrack.stop).not.toHaveBeenCalled()
+            expect(track.stop).toHaveBeenCalledOnce()
+            expect(peerConnection.close).not.toHaveBeenCalled()
         })
 
         test('should use default type and quality', () => {

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -5,8 +5,14 @@ function createRecorderModule() {
     return new RecorderModule()
 }
 
-function createMockCanvas(options: { toDataURL?: string } = {}) {
+function createMockCanvas(options: {
+    width?: number
+    height?: number
+    toDataURL?: string
+} = {}) {
     const canvas = document.createElement('canvas')
+    canvas.width = options.width ?? 1280
+    canvas.height = options.height ?? 720
     vi.spyOn(canvas, 'toDataURL').mockReturnValue(options.toDataURL || 'data:image/png;base64,mockData')
     canvas.captureStream = vi.fn().mockReturnValue({
         getTracks: () => [{ stop: vi.fn() }],
@@ -52,6 +58,7 @@ describe('RecorderModule', () => {
     })
 
     afterEach(() => {
+        vi.unstubAllGlobals()
         if (canvas) {
             canvas.remove()
             canvas = null
@@ -434,11 +441,16 @@ describe('RecorderModule', () => {
             expect(result).toEqual({ success: false, reason: 'Canvas not found', data: null })
         })
 
-        test('should return base64 data from canvas', () => {
+        test('should wait for paint and return base64 data from canvas', async () => {
             canvas = createMockCanvas({ toDataURL: 'data:image/png;base64,screenshotData' })
+            vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+                callback(0)
+                return 1
+            })
+            vi.stubGlobal('cancelAnimationFrame', vi.fn())
 
             const module = createRecorderModule()
-            const result = module.takeScreenshot()
+            const result = await module.takeScreenshotAfterPaint()
 
             expect(result).toEqual({
                 success: true,
@@ -463,6 +475,41 @@ describe('RecorderModule', () => {
             module.takeScreenshot({ type: 'image/jpeg', quality: 0.5 })
 
             expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.5)
+        })
+
+        test('should return an error when canvas serialization fails', () => {
+            canvas = createMockCanvas()
+            vi.spyOn(canvas, 'toDataURL').mockImplementation(() => {
+                throw new DOMException('Canvas is tainted', 'SecurityError')
+            })
+
+            const module = createRecorderModule()
+
+            expect(module.takeScreenshot()).toEqual({
+                success: false,
+                reason: 'Canvas is tainted',
+                data: null,
+            })
+        })
+
+        test('should downscale oversized screenshots', () => {
+            canvas = createMockCanvas({ width: 3840, height: 2160 })
+            const resizedCanvas = document.createElement('canvas')
+            const drawImage = vi.fn()
+            vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+                if (tagName === 'canvas') return resizedCanvas
+                throw new Error(`Unexpected element: ${tagName}`)
+            })
+            vi.spyOn(resizedCanvas, 'getContext').mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D)
+            vi.spyOn(resizedCanvas, 'toDataURL').mockReturnValue('data:image/png;base64,resized')
+
+            const module = createRecorderModule()
+            const result = module.takeScreenshot({ maxWidth: 1920, maxHeight: 1080 })
+
+            expect(resizedCanvas.width).toBe(1920)
+            expect(resizedCanvas.height).toBe(1080)
+            expect(drawImage).toHaveBeenCalledWith(canvas, 0, 0, 1920, 1080)
+            expect(result.data).toBe('data:image/png;base64,resized')
         })
     })
 


### PR DESCRIPTION
## Summary

- keep the existing synchronous screenshot API backward-compatible
- capture QA screenshots from the painted canvas surface through a short-lived local media track
- support WebGL canvases without relying on drawing-buffer preservation
- resize and encode screenshots in the bridge, return structured failures, and echo request IDs
- stop only the temporary screenshot track when recording is active

## Validation

- npm test (107 tests)
- npm run lint
- npm run build
- Chromium WebGL smoke with preserveDrawingBuffer disabled
