### PR TITLE
QA-tool: Daily rewards

### DIFF
--- a/src/constants/eventName.ts
+++ b/src/constants/eventName.ts
@@ -29,5 +29,7 @@ export const EVENT_NAME = {
     VISIBILITY_STATE_CHANGED: 'visibility_state_changed',
     STORAGE_SET: 'storage_set',
     CROSS_PROMO_SHOWN: 'cross_promo_shown',
+    DAILY_REWARDS_CLAIMED: 'daily_rewards_claimed',
+    DAILY_REWARDS_STREAK_RESET: 'daily_rewards_streak_reset',
 } as const
 export type EventName = typeof EVENT_NAME[keyof typeof EVENT_NAME]

--- a/src/modules/daily-rewards/DailyRewardsModule.ts
+++ b/src/modules/daily-rewards/DailyRewardsModule.ts
@@ -19,10 +19,13 @@ import ModuleBase from '../ModuleBase'
 import type { AnyRecord } from '../../utils'
 import bridgeConfig from '../../lib/bridge-config'
 import storageModule from '../storage'
+import { EVENT_NAME } from '../../constants'
 import { DAILY_REWARDS_STORAGE_KEY, MS_PER_DAY } from './constants'
 import type {
     DailyRewardsState,
     DailyRewardsBridgeContract,
+    DailyRewardsClaimedPayload,
+    DailyRewardsStreakResetPayload,
 } from './types'
 
 /**
@@ -31,6 +34,15 @@ import type {
  * using the platform server time (converted to a UTC epoch-day number, with a local
  * Date.now() fallback), persists progress through the storage module, and resets the
  * streak back to the first day when one or more days are missed.
+ *
+ * Claim and streak-reset activity is emitted on the platform bridge
+ * (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET); bridges that
+ * surface it to an external tool (e.g. QA Tool) subscribe to these events.
+ *
+ * Every public operation reads the clock exactly once up front and passes the
+ * epoch day down. Each state check runs in the same synchronous block as the
+ * write it guards, so concurrent operations cannot interleave between a check
+ * and its write.
  */
 class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
     #rewards: string[] = []
@@ -60,53 +72,59 @@ class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
 
     // 0-based index (into the rewards list) of the reward the player is currently on.
     async getCurrentDay(): Promise<number> {
-        const state = await this.#refresh()
+        const todayEpochDay = await this.#getTodayEpochDay()
+        const state = await this.#refresh(todayEpochDay)
         return state.day
     }
 
     // Id of the reward claimable today, or null when nothing can be claimed.
     async getCurrentReward(): Promise<string | null> {
-        const state = await this.#refresh()
-        if (!(await this.#canClaim(state))) {
+        const todayEpochDay = await this.#getTodayEpochDay()
+        const state = await this.#refresh(todayEpochDay)
+        if (!this.#canClaim(state, todayEpochDay)) {
             return null
         }
         return this.#rewards[state.day]
     }
 
     async claimCurrentReward(): Promise<boolean> {
-        const state = await this.#refresh()
-        if (!(await this.#canClaim(state))) {
+        const todayEpochDay = await this.#getTodayEpochDay()
+        const state = await this.#refresh(todayEpochDay)
+        if (!this.#canClaim(state, todayEpochDay)) {
             return false
         }
 
-        state.lastClaimEpochDay = await this.#getTodayEpochDay()
+        const claimedDay = state.day
+        state.lastClaimEpochDay = todayEpochDay
         state.day = this.#cycle ? (state.day + 1) % this.#rewards.length : state.day + 1
 
         await this.#persist()
+        const payload: DailyRewardsClaimedPayload = {
+            day: claimedDay,
+            reward: this.#rewards[claimedDay],
+        }
+        this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, payload)
         return true
     }
 
-    async #refresh(): Promise<DailyRewardsState> {
+    async #refresh(todayEpochDay: number): Promise<DailyRewardsState> {
         const state = await this.#load()
-        if (this.#resetOnMiss && state.lastClaimEpochDay !== null && state.day > 0) {
-            const todayEpochDay = await this.#getTodayEpochDay()
-            if (todayEpochDay - state.lastClaimEpochDay >= 2) {
-                state.day = 0
-                await this.#persist()
-            }
+        if (this.#resetOnMiss && state.lastClaimEpochDay !== null && state.day > 0
+            && todayEpochDay - state.lastClaimEpochDay >= 2) {
+            const missedDay = state.day
+            state.day = 0
+            await this.#persist()
+            const payload: DailyRewardsStreakResetPayload = { day: missedDay }
+            this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, payload)
         }
         return state
     }
 
-    async #canClaim(state: DailyRewardsState): Promise<boolean> {
+    #canClaim(state: DailyRewardsState, todayEpochDay: number): boolean {
         if (state.day >= this.#rewards.length) {
             return false
         }
-        if (state.lastClaimEpochDay === null) {
-            return true
-        }
-        const todayEpochDay = await this.#getTodayEpochDay()
-        return todayEpochDay > state.lastClaimEpochDay
+        return state.lastClaimEpochDay === null || todayEpochDay > state.lastClaimEpochDay
     }
 
     async #getTodayEpochDay(): Promise<number> {

--- a/src/modules/daily-rewards/DailyRewardsModule.ts
+++ b/src/modules/daily-rewards/DailyRewardsModule.ts
@@ -17,6 +17,7 @@
 
 import ModuleBase from '../ModuleBase'
 import type { AnyRecord } from '../../utils'
+import eventBus from '../../lib/EventBus'
 import bridgeConfig from '../../lib/bridge-config'
 import storageModule from '../storage'
 import { EVENT_NAME } from '../../constants'
@@ -35,9 +36,11 @@ import type {
  * Date.now() fallback), persists progress through the storage module, and resets the
  * streak back to the first day when one or more days are missed.
  *
- * Claim and streak-reset activity is emitted on the platform bridge
- * (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET); bridges that
- * surface it to an external tool (e.g. QA Tool) subscribe to these events.
+ * Claim and streak-reset activity is emitted on the global event bus
+ * (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET) — the same bus
+ * the public bridge.on() is wired to, like every other module event — so both
+ * game code and bridges that surface it to an external tool (e.g. QA Tool)
+ * can subscribe.
  *
  * Every public operation reads the clock exactly once up front and passes the
  * epoch day down. Each state check runs in the same synchronous block as the
@@ -103,7 +106,7 @@ class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
             day: claimedDay,
             reward: this.#rewards[claimedDay],
         }
-        this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, payload)
+        eventBus.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, payload)
         return true
     }
 
@@ -115,7 +118,7 @@ class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
             state.day = 0
             await this.#persist()
             const payload: DailyRewardsStreakResetPayload = { day: missedDay }
-            this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, payload)
+            eventBus.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, payload)
         }
         return state
     }

--- a/src/modules/daily-rewards/types.ts
+++ b/src/modules/daily-rewards/types.ts
@@ -33,7 +33,7 @@ export interface DailyRewardsState {
     lastClaimEpochDay: number | null
 }
 
-// Payloads of the daily rewards events emitted on the platform bridge
+// Payloads of the daily rewards events emitted on the global event bus
 // (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET).
 export interface DailyRewardsClaimedPayload {
     day: number

--- a/src/modules/daily-rewards/types.ts
+++ b/src/modules/daily-rewards/types.ts
@@ -33,6 +33,17 @@ export interface DailyRewardsState {
     lastClaimEpochDay: number | null
 }
 
+// Payloads of the daily rewards events emitted on the platform bridge
+// (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET).
+export interface DailyRewardsClaimedPayload {
+    day: number
+    reward: string
+}
+
+export interface DailyRewardsStreakResetPayload {
+    day: number
+}
+
 export interface DailyRewardsBridgeContract extends PlatformBridgeLike {
     platformId: PlatformId
     options?: AnyRecord

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -379,6 +379,8 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                         loadError: bridgeConfig.loadError,
                         parseError: bridgeConfig.parseError,
                         options: bridgeConfig.getRawValues(),
+                        // What modules actually consume; the QA tool reads module configs from here
+                        resolvedOptions: bridgeConfig.getValues(),
                         path: bridgeConfig.path,
                         remoteLoadStatus: bridgeConfig.remoteLoadStatus,
                         remoteLoadError: bridgeConfig.remoteLoadError,

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -41,6 +41,10 @@ import {
 import { LEADERBOARD_TYPE, type LeaderboardType } from '../modules/leaderboards/constants'
 import type { NormalizedAchievement } from '../modules/achievements/types'
 import type { CrossPromoShownPayload } from '../modules/cross-promo/types'
+import type {
+    DailyRewardsClaimedPayload,
+    DailyRewardsStreakResetPayload,
+} from '../modules/daily-rewards/types'
 import type { AnyRecord } from '../utils'
 import type { SafeAreaInsets } from '../lib/safe-area'
 
@@ -80,6 +84,10 @@ export const ACTION_NAME_QA = {
     SHOW_ADVANCED_BANNERS: 'show_advanced_banners',
     HIDE_ADVANCED_BANNERS: 'hide_advanced_banners',
     CROSS_PROMO_SHOWN: 'cross_promo_shown',
+    // Outbound notifications (events that already happened), not commands:
+    // the imperative daily_rewards_* names stay free for future QA tool commands.
+    DAILY_REWARDS_CLAIMED: 'daily_rewards_claimed',
+    DAILY_REWARDS_STREAK_RESET: 'daily_rewards_streak_reset',
 } as const
 export type ActionNameQa = typeof ACTION_NAME_QA[keyof typeof ACTION_NAME_QA]
 
@@ -310,6 +318,20 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 this.#sendMessage({
                     type: MODULE_NAME.CROSS_PROMO,
                     action: ACTION_NAME_QA.CROSS_PROMO_SHOWN,
+                    options: { ...payload },
+                })
+            })
+            this.on(EVENT_NAME.DAILY_REWARDS_CLAIMED, (payload: DailyRewardsClaimedPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.DAILY_REWARDS,
+                    action: ACTION_NAME_QA.DAILY_REWARDS_CLAIMED,
+                    options: { ...payload },
+                })
+            })
+            this.on(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, (payload: DailyRewardsStreakResetPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.DAILY_REWARDS,
+                    action: ACTION_NAME_QA.DAILY_REWARDS_STREAK_RESET,
                     options: { ...payload },
                 })
             })

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -321,14 +321,14 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                     options: { ...payload },
                 })
             })
-            this.on(EVENT_NAME.DAILY_REWARDS_CLAIMED, (payload: DailyRewardsClaimedPayload) => {
+            eventBus.on(EVENT_NAME.DAILY_REWARDS_CLAIMED, (payload: DailyRewardsClaimedPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.DAILY_REWARDS,
                     action: ACTION_NAME_QA.DAILY_REWARDS_CLAIMED,
                     options: { ...payload },
                 })
             })
-            this.on(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, (payload: DailyRewardsStreakResetPayload) => {
+            eventBus.on(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, (payload: DailyRewardsStreakResetPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.DAILY_REWARDS,
                     action: ACTION_NAME_QA.DAILY_REWARDS_STREAK_RESET,

--- a/tests/src/modules/dailyRewardsModule.spec.ts
+++ b/tests/src/modules/dailyRewardsModule.spec.ts
@@ -1,0 +1,189 @@
+import {
+    describe, test, expect, vi, beforeEach,
+} from 'vitest'
+import DailyRewardsModule from '../../../src/modules/daily-rewards/DailyRewardsModule'
+import bridgeConfig from '../../../src/lib/bridge-config'
+import { MS_PER_DAY } from '../../../src/modules/daily-rewards/constants'
+import { EVENT_NAME } from '../../../src/constants'
+import type { DailyRewardsBridgeContract } from '../../../src/modules/daily-rewards/types'
+
+const { store } = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
+
+vi.mock('../../../src/modules/storage', () => ({
+    default: {
+        get: vi.fn((key: string) => Promise.resolve(
+            store.has(key) ? JSON.parse(JSON.stringify(store.get(key))) : null,
+        )),
+        set: vi.fn((key: string, value: unknown) => {
+            store.set(key, JSON.parse(JSON.stringify(value)))
+            return Promise.resolve()
+        }),
+    },
+}))
+
+vi.mock('../../../src/lib/bridge-config', () => ({
+    default: {
+        getValues: vi.fn(() => ({})),
+    },
+}))
+
+const BASE_MS = 100 * MS_PER_DAY
+
+// A bridge with a movable server clock and a spied event emitter.
+function createBridge() {
+    const clock = { ms: BASE_MS }
+    return {
+        platformId: 'mock',
+        getServerTime: vi.fn(() => Promise.resolve(clock.ms)),
+        emit: vi.fn(),
+        clock,
+    }
+}
+
+function createModule(bridge: ReturnType<typeof createBridge>) {
+    return new DailyRewardsModule().initialize(bridge as unknown as DailyRewardsBridgeContract)
+}
+
+function emitted(bridge: ReturnType<typeof createBridge>, eventName: string) {
+    return bridge.emit.mock.calls.filter(([name]) => name === eventName)
+}
+
+describe('DailyRewardsModule', () => {
+    beforeEach(() => {
+        store.clear()
+        vi.mocked(bridgeConfig.getValues).mockReturnValue({
+            dailyRewards: { rewards: ['a', 'b', 'c'] },
+        })
+    })
+
+    test('successful claim emits the claimed event', async () => {
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(bridge.emit).toHaveBeenCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 0, reward: 'a' },
+        )
+    })
+
+    test('same-day repeated claim is rejected and does not emit', async () => {
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        await module.claimCurrentReward()
+        expect(await module.claimCurrentReward()).toBe(false)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+    })
+
+    test('missed-day reset emits the streak reset event', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+
+        bridge.clock.ms += 3 * MS_PER_DAY
+        const module = createModule(bridge)
+
+        expect(await module.getCurrentDay()).toBe(0)
+        expect(bridge.emit).toHaveBeenCalledWith(
+            EVENT_NAME.DAILY_REWARDS_STREAK_RESET,
+            { day: 1 },
+        )
+    })
+
+    test('concurrent claims grant a single reward', async () => {
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        const results = await Promise.all([
+            module.claimCurrentReward(),
+            module.claimCurrentReward(),
+        ])
+
+        expect(results.filter(Boolean)).toHaveLength(1)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+        expect(await module.getCurrentDay()).toBe(1)
+    })
+
+    test('concurrent refreshes emit a single reset', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+
+        bridge.clock.ms += 3 * MS_PER_DAY
+        const module = createModule(bridge)
+
+        await Promise.all([module.getCurrentDay(), module.getCurrentReward()])
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+    })
+
+    test('claim racing a missed-day reset claims the first day', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+
+        bridge.clock.ms += 3 * MS_PER_DAY
+        const module = createModule(bridge)
+
+        const [, claimed] = await Promise.all([
+            module.getCurrentDay(),
+            module.claimCurrentReward(),
+        ])
+
+        expect(claimed).toBe(true)
+        expect(bridge.emit).toHaveBeenCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 0, reward: 'a' },
+        )
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+    })
+
+    test('single reward with cycle relies on the claim date alone', async () => {
+        vi.mocked(bridgeConfig.getValues).mockReturnValue({
+            dailyRewards: { rewards: ['a'] },
+        })
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(await module.getCurrentDay()).toBe(0)
+        expect(await module.claimCurrentReward()).toBe(false)
+
+        bridge.clock.ms += MS_PER_DAY
+        expect(await createModule(bridge).claimCurrentReward()).toBe(true)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+    })
+
+    test('claiming the last reward wraps to the first day when cycle is on', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+        bridge.clock.ms += MS_PER_DAY
+        await createModule(bridge).claimCurrentReward()
+        bridge.clock.ms += MS_PER_DAY
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(bridge.emit).toHaveBeenLastCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 2, reward: 'c' },
+        )
+        expect(await module.getCurrentDay()).toBe(0)
+    })
+
+    test('claims stop after the last reward when cycle is off', async () => {
+        vi.mocked(bridgeConfig.getValues).mockReturnValue({
+            dailyRewards: { rewards: ['a', 'b'], cycle: false },
+        })
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+        bridge.clock.ms += MS_PER_DAY
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(bridge.emit).toHaveBeenLastCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 1, reward: 'b' },
+        )
+
+        bridge.clock.ms += MS_PER_DAY
+        expect(await createModule(bridge).claimCurrentReward()).toBe(false)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+    })
+})

--- a/tests/src/modules/dailyRewardsModule.spec.ts
+++ b/tests/src/modules/dailyRewardsModule.spec.ts
@@ -2,6 +2,7 @@ import {
     describe, test, expect, vi, beforeEach,
 } from 'vitest'
 import DailyRewardsModule from '../../../src/modules/daily-rewards/DailyRewardsModule'
+import eventBus from '../../../src/lib/EventBus'
 import bridgeConfig from '../../../src/lib/bridge-config'
 import { MS_PER_DAY } from '../../../src/modules/daily-rewards/constants'
 import { EVENT_NAME } from '../../../src/constants'
@@ -29,28 +30,31 @@ vi.mock('../../../src/lib/bridge-config', () => ({
 
 const BASE_MS = 100 * MS_PER_DAY
 
-// A bridge with a movable server clock and a spied event emitter.
+// A bridge with a movable server clock. Events are emitted on the global
+// event bus, not on the bridge, so the bus emit is spied instead.
 function createBridge() {
     const clock = { ms: BASE_MS }
     return {
         platformId: 'mock',
         getServerTime: vi.fn(() => Promise.resolve(clock.ms)),
-        emit: vi.fn(),
         clock,
     }
 }
+
+const busEmit = vi.spyOn(eventBus, 'emit')
 
 function createModule(bridge: ReturnType<typeof createBridge>) {
     return new DailyRewardsModule().initialize(bridge as unknown as DailyRewardsBridgeContract)
 }
 
-function emitted(bridge: ReturnType<typeof createBridge>, eventName: string) {
-    return bridge.emit.mock.calls.filter(([name]) => name === eventName)
+function emitted(eventName: string) {
+    return busEmit.mock.calls.filter(([name]) => name === eventName)
 }
 
 describe('DailyRewardsModule', () => {
     beforeEach(() => {
         store.clear()
+        busEmit.mockClear()
         vi.mocked(bridgeConfig.getValues).mockReturnValue({
             dailyRewards: { rewards: ['a', 'b', 'c'] },
         })
@@ -61,7 +65,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.claimCurrentReward()).toBe(true)
-        expect(bridge.emit).toHaveBeenCalledWith(
+        expect(busEmit).toHaveBeenCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 0, reward: 'a' },
         )
@@ -73,7 +77,7 @@ describe('DailyRewardsModule', () => {
 
         await module.claimCurrentReward()
         expect(await module.claimCurrentReward()).toBe(false)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
     })
 
     test('missed-day reset emits the streak reset event', async () => {
@@ -84,7 +88,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.getCurrentDay()).toBe(0)
-        expect(bridge.emit).toHaveBeenCalledWith(
+        expect(busEmit).toHaveBeenCalledWith(
             EVENT_NAME.DAILY_REWARDS_STREAK_RESET,
             { day: 1 },
         )
@@ -100,7 +104,7 @@ describe('DailyRewardsModule', () => {
         ])
 
         expect(results.filter(Boolean)).toHaveLength(1)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
         expect(await module.getCurrentDay()).toBe(1)
     })
 
@@ -112,7 +116,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         await Promise.all([module.getCurrentDay(), module.getCurrentReward()])
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
     })
 
     test('claim racing a missed-day reset claims the first day', async () => {
@@ -128,11 +132,11 @@ describe('DailyRewardsModule', () => {
         ])
 
         expect(claimed).toBe(true)
-        expect(bridge.emit).toHaveBeenCalledWith(
+        expect(busEmit).toHaveBeenCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 0, reward: 'a' },
         )
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
     })
 
     test('single reward with cycle relies on the claim date alone', async () => {
@@ -148,7 +152,7 @@ describe('DailyRewardsModule', () => {
 
         bridge.clock.ms += MS_PER_DAY
         expect(await createModule(bridge).claimCurrentReward()).toBe(true)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
     })
 
     test('claiming the last reward wraps to the first day when cycle is on', async () => {
@@ -160,7 +164,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.claimCurrentReward()).toBe(true)
-        expect(bridge.emit).toHaveBeenLastCalledWith(
+        expect(busEmit).toHaveBeenLastCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 2, reward: 'c' },
         )
@@ -177,13 +181,13 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.claimCurrentReward()).toBe(true)
-        expect(bridge.emit).toHaveBeenLastCalledWith(
+        expect(busEmit).toHaveBeenLastCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 1, reward: 'b' },
         )
 
         bridge.clock.ms += MS_PER_DAY
         expect(await createModule(bridge).claimCurrentReward()).toBe(false)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
     })
 })

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -84,4 +84,16 @@ describe('QaToolPlatformBridge modules wire format', () => {
             options: { day: 4 },
         })
     })
+
+    test('initialize payload carries platform-resolved config options', () => {
+        createInitializedBridge()
+
+        const initializeMessage = sendSpy.mock.calls
+            .map(([message]) => message as { action?: string, payload?: Record<string, unknown> })
+            .find((message) => message.action === 'initialize')
+
+        expect(initializeMessage).toBeDefined()
+        const configFile = initializeMessage?.payload?.configFile as Record<string, unknown>
+        expect(configFile.resolvedOptions).toBeDefined()
+    })
 })

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -29,6 +29,8 @@ describe('QaToolPlatformBridge modules wire format', () => {
         sendSpy.mockClear()
         // The bus is a singleton; drop subscriptions left by bridges from
         // previous tests so each test observes exactly one forwarder.
+        eventBus.off(EVENT_NAME.DAILY_REWARDS_CLAIMED)
+        eventBus.off(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)
         eventBus.off(EVENT_NAME.CROSS_PROMO_SHOWN)
     })
 
@@ -60,9 +62,9 @@ describe('QaToolPlatformBridge modules wire format', () => {
     })
 
     test('claimed event is forwarded as a daily_rewards_claimed message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, { day: 2, reward: 'gem' })
+        eventBus.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, { day: 2, reward: 'gem' })
 
         expect(sendSpy).toHaveBeenLastCalledWith({
             source: 'bridge',
@@ -73,9 +75,9 @@ describe('QaToolPlatformBridge modules wire format', () => {
     })
 
     test('streak reset event is forwarded as a daily_rewards_streak_reset message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, { day: 4 })
+        eventBus.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, { day: 4 })
 
         expect(sendSpy).toHaveBeenLastCalledWith({
             source: 'bridge',

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -24,7 +24,7 @@ vi.stubGlobal('PLUGIN_VERSION', 'test-version')
 // Pins the outbound wire format consumed by the external QA tool. The literals
 // are intentional: renaming a constant must break this test, not silently
 // change the protocol.
-describe('QaToolPlatformBridge cross promo wire format', () => {
+describe('QaToolPlatformBridge modules wire format', () => {
     beforeEach(() => {
         sendSpy.mockClear()
         // The bus is a singleton; drop subscriptions left by bridges from
@@ -56,6 +56,32 @@ describe('QaToolPlatformBridge cross promo wire format', () => {
                 source: 'config',
                 games: [{ url: 'https://example.com/pixel-run', name: 'Pixel Run' }],
             },
+        })
+    })
+
+    test('claimed event is forwarded as a daily_rewards_claimed message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, { day: 2, reward: 'gem' })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'daily_rewards',
+            action: 'daily_rewards_claimed',
+            options: { day: 2, reward: 'gem' },
+        })
+    })
+
+    test('streak reset event is forwarded as a daily_rewards_streak_reset message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, { day: 4 })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'daily_rewards',
+            action: 'daily_rewards_streak_reset',
+            options: { day: 4 },
         })
     })
 })


### PR DESCRIPTION
## Summary

- add `EVENT_NAME.DAILY_REWARDS_CLAIMED` / `DAILY_REWARDS_STREAK_RESET` with named
  payload types; the module emits them on the global event bus (the one the public
  `bridge.on()` is wired to) after a successful persist
- read the clock once per operation: the epoch day is computed at the entry point
  and passed down to `#refresh` / `#canClaim`
- `QaToolPlatformBridge` forwards both events to the external QA tool via
  `ACTION_NAME_QA` (`daily_rewards_claimed` / `daily_rewards_streak_reset`)
- initialize payload carries `configFile.resolvedOptions` (`bridgeConfig.getValues()`),
  so the QA tool reads the same module configs the SDK actually uses
- tests: claim vs reset race, concurrent claims, `cycle` on/off, last-day
  boundaries; wire format pinned with literals in `qaToolPlatformBridge.spec.ts`

Module mechanics (claim rules, `cycle`, `resetOnMiss`) and the package version are
unchanged.

## Validation

- `npm test` (113 tests)
- `npm run lint`
- `npm run build`
- `npm run build:types`