### PR TITLE
Allow recorder capture to use configured ICE servers

### DIFF
--- a/src/lib/Recorder.ts
+++ b/src/lib/Recorder.ts
@@ -22,6 +22,7 @@ export type RecorderPriority = 'very-low' | 'low' | 'medium' | 'high'
 
 export interface RecorderStartOptions {
     fps?: number
+    iceServers?: RTCIceServer[]
     maxBitrate?: number
     minBitrate?: number
     maxFramerate?: number
@@ -112,7 +113,9 @@ class Recorder {
         this.#stream = stream
         let peerConnection: RTCPeerConnection
         try {
-            peerConnection = new RTCPeerConnection()
+            peerConnection = options.iceServers?.length
+                ? new RTCPeerConnection({ iceServers: options.iceServers })
+                : new RTCPeerConnection()
         } catch (error) {
             this.#clearCaptureResources()
             throw error

--- a/tests/src/lib/recorder.spec.ts
+++ b/tests/src/lib/recorder.spec.ts
@@ -188,10 +188,26 @@ describe('Recorder', () => {
             module.onStarted = onStarted
             await module.startCapture()
 
+            expect(global.RTCPeerConnection).toHaveBeenCalledWith()
             expect(mockPc.createOffer).toHaveBeenCalled()
             expect(mockPc.setLocalDescription).toHaveBeenCalled()
             expect(onOffer).toHaveBeenCalledWith('mock-offer-sdp')
             expect(onStarted).toHaveBeenCalled()
+        })
+
+        test('should configure the peer connection with provided ICE servers', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+            const iceServers: RTCIceServer[] = [{
+                urls: 'turn:turn.example.com',
+                username: 'user',
+                credential: 'credential',
+            }]
+
+            const module = createRecorder()
+            await module.startCapture({ iceServers })
+
+            expect(global.RTCPeerConnection).toHaveBeenCalledWith({ iceServers })
         })
 
         test('should use custom fps', async () => {


### PR DESCRIPTION
## Summary

- allow recorder capture to use an optional standard ICE server configuration
- preserve the existing peer connection behavior when no ICE servers are provided
- cover both configured and default construction paths

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
- `npm run build:types`
