### PR TITLE
Allow recorder capture to use configured ICE servers

### DIFF
--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -68,6 +68,7 @@ class RecorderModule {
      * Starts canvas capture and creates a WebRTC offer.
      * @param {Object} [options]
      * @param {number} [options.fps=30] - Capture frame rate passed to captureStream()
+     * @param {RTCIceServer[]} [options.iceServers] - ICE servers used by the capture peer connection
      * @param {number} [options.maxBitrate] - Maximum bitrate in bits/s
      * @param {number} [options.minBitrate] - Minimum bitrate in bits/s
      * @param {number} [options.maxFramerate] - Maximum framerate at encoding level
@@ -93,7 +94,9 @@ class RecorderModule {
         this.#stream = stream
         let peerConnection
         try {
-            peerConnection = new RTCPeerConnection()
+            peerConnection = options.iceServers?.length
+                ? new RTCPeerConnection({ iceServers: options.iceServers })
+                : new RTCPeerConnection()
         } catch (error) {
             this.#clearCaptureResources()
             throw error

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -182,10 +182,26 @@ describe('RecorderModule', () => {
             module.onStarted = onStarted
             await module.startCapture()
 
+            expect(global.RTCPeerConnection).toHaveBeenCalledWith()
             expect(mockPc.createOffer).toHaveBeenCalled()
             expect(mockPc.setLocalDescription).toHaveBeenCalled()
             expect(onOffer).toHaveBeenCalledWith('mock-offer-sdp')
             expect(onStarted).toHaveBeenCalled()
+        })
+
+        test('should configure the peer connection with provided ICE servers', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+            const iceServers: RTCIceServer[] = [{
+                urls: 'turn:turn.example.com',
+                username: 'user',
+                credential: 'credential',
+            }]
+
+            const module = createRecorderModule()
+            await module.startCapture({ iceServers })
+
+            expect(global.RTCPeerConnection).toHaveBeenCalledWith({ iceServers })
         })
 
         test('should use custom fps', async () => {


### PR DESCRIPTION
## Summary

- allow recorder capture to use an optional standard ICE server configuration
- preserve the existing peer connection behavior when no ICE servers are provided
- cover both configured and default construction paths

## Verification

- `npm test`
- `npm run lint`
- `npm run build`
