### PR TITLE
QA-tool tasks events

### DIFF
--- a/src/constants/eventName.ts
+++ b/src/constants/eventName.ts
@@ -29,5 +29,7 @@ export const EVENT_NAME = {
     VISIBILITY_STATE_CHANGED: 'visibility_state_changed',
     STORAGE_SET: 'storage_set',
     CROSS_PROMO_SHOWN: 'cross_promo_shown',
+    DAILY_REWARDS_CLAIMED: 'daily_rewards_claimed',
+    DAILY_REWARDS_STREAK_RESET: 'daily_rewards_streak_reset',
 } as const
 export type EventName = typeof EVENT_NAME[keyof typeof EVENT_NAME]

--- a/src/constants/eventName.ts
+++ b/src/constants/eventName.ts
@@ -31,5 +31,7 @@ export const EVENT_NAME = {
     CROSS_PROMO_SHOWN: 'cross_promo_shown',
     DAILY_REWARDS_CLAIMED: 'daily_rewards_claimed',
     DAILY_REWARDS_STREAK_RESET: 'daily_rewards_streak_reset',
+    TASKS_REWARD_CLAIMED: 'tasks_reward_claimed',
+    TASKS_PERIOD_ROLLED_OVER: 'tasks_period_rolled_over',
 } as const
 export type EventName = typeof EVENT_NAME[keyof typeof EVENT_NAME]

--- a/src/modules/daily-rewards/DailyRewardsModule.ts
+++ b/src/modules/daily-rewards/DailyRewardsModule.ts
@@ -19,10 +19,13 @@ import ModuleBase from '../ModuleBase'
 import type { AnyRecord } from '../../utils'
 import bridgeConfig from '../../lib/bridge-config'
 import storageModule from '../storage'
+import { EVENT_NAME } from '../../constants'
 import { DAILY_REWARDS_STORAGE_KEY, MS_PER_DAY } from './constants'
 import type {
     DailyRewardsState,
     DailyRewardsBridgeContract,
+    DailyRewardsClaimedPayload,
+    DailyRewardsStreakResetPayload,
 } from './types'
 
 /**
@@ -31,6 +34,15 @@ import type {
  * using the platform server time (converted to a UTC epoch-day number, with a local
  * Date.now() fallback), persists progress through the storage module, and resets the
  * streak back to the first day when one or more days are missed.
+ *
+ * Claim and streak-reset activity is emitted on the platform bridge
+ * (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET); bridges that
+ * surface it to an external tool (e.g. QA Tool) subscribe to these events.
+ *
+ * Every public operation reads the clock exactly once up front and passes the
+ * epoch day down. Each state check runs in the same synchronous block as the
+ * write it guards, so concurrent operations cannot interleave between a check
+ * and its write.
  */
 class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
     #rewards: string[] = []
@@ -60,53 +72,59 @@ class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
 
     // 0-based index (into the rewards list) of the reward the player is currently on.
     async getCurrentDay(): Promise<number> {
-        const state = await this.#refresh()
+        const todayEpochDay = await this.#getTodayEpochDay()
+        const state = await this.#refresh(todayEpochDay)
         return state.day
     }
 
     // Id of the reward claimable today, or null when nothing can be claimed.
     async getCurrentReward(): Promise<string | null> {
-        const state = await this.#refresh()
-        if (!(await this.#canClaim(state))) {
+        const todayEpochDay = await this.#getTodayEpochDay()
+        const state = await this.#refresh(todayEpochDay)
+        if (!this.#canClaim(state, todayEpochDay)) {
             return null
         }
         return this.#rewards[state.day]
     }
 
     async claimCurrentReward(): Promise<boolean> {
-        const state = await this.#refresh()
-        if (!(await this.#canClaim(state))) {
+        const todayEpochDay = await this.#getTodayEpochDay()
+        const state = await this.#refresh(todayEpochDay)
+        if (!this.#canClaim(state, todayEpochDay)) {
             return false
         }
 
-        state.lastClaimEpochDay = await this.#getTodayEpochDay()
+        const claimedDay = state.day
+        state.lastClaimEpochDay = todayEpochDay
         state.day = this.#cycle ? (state.day + 1) % this.#rewards.length : state.day + 1
 
         await this.#persist()
+        const payload: DailyRewardsClaimedPayload = {
+            day: claimedDay,
+            reward: this.#rewards[claimedDay],
+        }
+        this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, payload)
         return true
     }
 
-    async #refresh(): Promise<DailyRewardsState> {
+    async #refresh(todayEpochDay: number): Promise<DailyRewardsState> {
         const state = await this.#load()
-        if (this.#resetOnMiss && state.lastClaimEpochDay !== null && state.day > 0) {
-            const todayEpochDay = await this.#getTodayEpochDay()
-            if (todayEpochDay - state.lastClaimEpochDay >= 2) {
-                state.day = 0
-                await this.#persist()
-            }
+        if (this.#resetOnMiss && state.lastClaimEpochDay !== null && state.day > 0
+            && todayEpochDay - state.lastClaimEpochDay >= 2) {
+            const missedDay = state.day
+            state.day = 0
+            await this.#persist()
+            const payload: DailyRewardsStreakResetPayload = { day: missedDay }
+            this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, payload)
         }
         return state
     }
 
-    async #canClaim(state: DailyRewardsState): Promise<boolean> {
+    #canClaim(state: DailyRewardsState, todayEpochDay: number): boolean {
         if (state.day >= this.#rewards.length) {
             return false
         }
-        if (state.lastClaimEpochDay === null) {
-            return true
-        }
-        const todayEpochDay = await this.#getTodayEpochDay()
-        return todayEpochDay > state.lastClaimEpochDay
+        return state.lastClaimEpochDay === null || todayEpochDay > state.lastClaimEpochDay
     }
 
     async #getTodayEpochDay(): Promise<number> {

--- a/src/modules/daily-rewards/DailyRewardsModule.ts
+++ b/src/modules/daily-rewards/DailyRewardsModule.ts
@@ -17,6 +17,7 @@
 
 import ModuleBase from '../ModuleBase'
 import type { AnyRecord } from '../../utils'
+import eventBus from '../../lib/EventBus'
 import bridgeConfig from '../../lib/bridge-config'
 import storageModule from '../storage'
 import { EVENT_NAME } from '../../constants'
@@ -35,9 +36,11 @@ import type {
  * Date.now() fallback), persists progress through the storage module, and resets the
  * streak back to the first day when one or more days are missed.
  *
- * Claim and streak-reset activity is emitted on the platform bridge
- * (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET); bridges that
- * surface it to an external tool (e.g. QA Tool) subscribe to these events.
+ * Claim and streak-reset activity is emitted on the global event bus
+ * (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET) — the same bus
+ * the public bridge.on() is wired to, like every other module event — so both
+ * game code and bridges that surface it to an external tool (e.g. QA Tool)
+ * can subscribe.
  *
  * Every public operation reads the clock exactly once up front and passes the
  * epoch day down. Each state check runs in the same synchronous block as the
@@ -103,7 +106,7 @@ class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
             day: claimedDay,
             reward: this.#rewards[claimedDay],
         }
-        this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, payload)
+        eventBus.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, payload)
         return true
     }
 
@@ -115,7 +118,7 @@ class DailyRewardsModule extends ModuleBase<DailyRewardsBridgeContract> {
             state.day = 0
             await this.#persist()
             const payload: DailyRewardsStreakResetPayload = { day: missedDay }
-            this._platformBridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, payload)
+            eventBus.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, payload)
         }
         return state
     }

--- a/src/modules/daily-rewards/types.ts
+++ b/src/modules/daily-rewards/types.ts
@@ -33,7 +33,7 @@ export interface DailyRewardsState {
     lastClaimEpochDay: number | null
 }
 
-// Payloads of the daily rewards events emitted on the platform bridge
+// Payloads of the daily rewards events emitted on the global event bus
 // (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET).
 export interface DailyRewardsClaimedPayload {
     day: number

--- a/src/modules/daily-rewards/types.ts
+++ b/src/modules/daily-rewards/types.ts
@@ -33,6 +33,17 @@ export interface DailyRewardsState {
     lastClaimEpochDay: number | null
 }
 
+// Payloads of the daily rewards events emitted on the platform bridge
+// (EVENT_NAME.DAILY_REWARDS_CLAIMED / DAILY_REWARDS_STREAK_RESET).
+export interface DailyRewardsClaimedPayload {
+    day: number
+    reward: string
+}
+
+export interface DailyRewardsStreakResetPayload {
+    day: number
+}
+
 export interface DailyRewardsBridgeContract extends PlatformBridgeLike {
     platformId: PlatformId
     options?: AnyRecord

--- a/src/modules/tasks/TasksModule.ts
+++ b/src/modules/tasks/TasksModule.ts
@@ -19,6 +19,7 @@ import ModuleBase from '../ModuleBase'
 import type { AnyRecord } from '../../utils'
 import bridgeConfig from '../../lib/bridge-config'
 import storageModule from '../storage'
+import { EVENT_NAME } from '../../constants'
 import {
     TASKS_STORAGE_KEY,
     MS_PER_DAY,
@@ -35,6 +36,8 @@ import type {
     TargetProgress,
     TaskItemConfig,
     TaskGroupConfig,
+    TasksRewardClaimedPayload,
+    TasksPeriodRolledOverPayload,
 } from './types'
 
 /**
@@ -141,16 +144,25 @@ class TasksModule extends ModuleBase<TasksBridgeContract> {
 
         found.task.claimed = true
         await this.#persist()
+        const payload: TasksRewardClaimedPayload = {
+            taskId: item.id,
+            groupId: found.group.id,
+            type: found.group.type,
+            rewards: item.rewards.map((reward) => ({ id: reward.id, amount: reward.amount })),
+        }
+        this._platformBridge.emit(EVENT_NAME.TASKS_REWARD_CLAIMED, payload)
         return true
     }
 
     // Loads state, then for every group rolls over to fresh, zeroed tasks when its
     // period changed. Returns the state and the active groups so callers only ever
-    // touch live tasks.
+    // touch live tasks. The roll-over event fires only when a stored period is
+    // replaced — the very first sync of a group is a start, not a reset.
     async #sync(): Promise<{ state: TasksState, active: { group: TaskGroupConfig, key: string }[] }> {
         const state = await this.#load()
         const now = await this.#getNow()
         const active: { group: TaskGroupConfig, key: string }[] = []
+        const rolledOver: TasksPeriodRolledOverPayload[] = []
         let dirty = false
 
         this.#groups.forEach((group) => {
@@ -158,6 +170,14 @@ class TasksModule extends ModuleBase<TasksBridgeContract> {
             const period = this.#periodKey(group, now)
             const current = state.groups[key]
             if (!current || current.periodKey !== period) {
+                if (current) {
+                    rolledOver.push({
+                        groupId: key,
+                        type: group.type,
+                        periodKey: period,
+                        previousPeriodKey: current.periodKey,
+                    })
+                }
                 state.groups[key] = { periodKey: period, tasks: this.#buildInitialTasks(group) }
                 dirty = true
             }
@@ -167,6 +187,9 @@ class TasksModule extends ModuleBase<TasksBridgeContract> {
         if (dirty) {
             await this.#persist()
         }
+        rolledOver.forEach((payload) => {
+            this._platformBridge.emit(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, payload)
+        })
         return { state, active }
     }
 

--- a/src/modules/tasks/TasksModule.ts
+++ b/src/modules/tasks/TasksModule.ts
@@ -17,6 +17,7 @@
 
 import ModuleBase from '../ModuleBase'
 import type { AnyRecord } from '../../utils'
+import eventBus from '../../lib/EventBus'
 import bridgeConfig from '../../lib/bridge-config'
 import storageModule from '../storage'
 import { EVENT_NAME } from '../../constants'
@@ -150,7 +151,7 @@ class TasksModule extends ModuleBase<TasksBridgeContract> {
             type: found.group.type,
             rewards: item.rewards.map((reward) => ({ id: reward.id, amount: reward.amount })),
         }
-        this._platformBridge.emit(EVENT_NAME.TASKS_REWARD_CLAIMED, payload)
+        eventBus.emit(EVENT_NAME.TASKS_REWARD_CLAIMED, payload)
         return true
     }
 
@@ -188,7 +189,7 @@ class TasksModule extends ModuleBase<TasksBridgeContract> {
             await this.#persist()
         }
         rolledOver.forEach((payload) => {
-            this._platformBridge.emit(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, payload)
+            eventBus.emit(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, payload)
         })
         return { state, active }
     }

--- a/src/modules/tasks/types.ts
+++ b/src/modules/tasks/types.ts
@@ -104,6 +104,22 @@ export interface Task {
     claimed: boolean
 }
 
+// Payloads of the tasks events emitted on the platform bridge
+// (EVENT_NAME.TASKS_REWARD_CLAIMED / TASKS_PERIOD_ROLLED_OVER).
+export interface TasksRewardClaimedPayload {
+    taskId: string
+    groupId: string
+    type: TaskType
+    rewards: TaskReward[]
+}
+
+export interface TasksPeriodRolledOverPayload {
+    groupId: string
+    type: TaskType
+    periodKey: number
+    previousPeriodKey: number
+}
+
 export interface TasksBridgeContract extends PlatformBridgeLike {
     platformId: PlatformId
     options?: AnyRecord

--- a/src/modules/tasks/types.ts
+++ b/src/modules/tasks/types.ts
@@ -104,7 +104,7 @@ export interface Task {
     claimed: boolean
 }
 
-// Payloads of the tasks events emitted on the platform bridge
+// Payloads of the tasks events emitted on the global event bus
 // (EVENT_NAME.TASKS_REWARD_CLAIMED / TASKS_PERIOD_ROLLED_OVER).
 export interface TasksRewardClaimedPayload {
     taskId: string

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -45,6 +45,10 @@ import type {
     DailyRewardsClaimedPayload,
     DailyRewardsStreakResetPayload,
 } from '../modules/daily-rewards/types'
+import type {
+    TasksRewardClaimedPayload,
+    TasksPeriodRolledOverPayload,
+} from '../modules/tasks/types'
 import type { AnyRecord } from '../utils'
 import type { SafeAreaInsets } from '../lib/safe-area'
 
@@ -88,6 +92,8 @@ export const ACTION_NAME_QA = {
     // the imperative daily_rewards_* names stay free for future QA tool commands.
     DAILY_REWARDS_CLAIMED: 'daily_rewards_claimed',
     DAILY_REWARDS_STREAK_RESET: 'daily_rewards_streak_reset',
+    TASKS_REWARD_CLAIMED: 'tasks_reward_claimed',
+    TASKS_PERIOD_ROLLED_OVER: 'tasks_period_rolled_over',
 } as const
 export type ActionNameQa = typeof ACTION_NAME_QA[keyof typeof ACTION_NAME_QA]
 
@@ -332,6 +338,20 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 this.#sendMessage({
                     type: MODULE_NAME.DAILY_REWARDS,
                     action: ACTION_NAME_QA.DAILY_REWARDS_STREAK_RESET,
+                    options: { ...payload },
+                })
+            })
+            this.on(EVENT_NAME.TASKS_REWARD_CLAIMED, (payload: TasksRewardClaimedPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.TASKS,
+                    action: ACTION_NAME_QA.TASKS_REWARD_CLAIMED,
+                    options: { ...payload },
+                })
+            })
+            this.on(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, (payload: TasksPeriodRolledOverPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.TASKS,
+                    action: ACTION_NAME_QA.TASKS_PERIOD_ROLLED_OVER,
                     options: { ...payload },
                 })
             })

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -379,6 +379,8 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                         loadError: bridgeConfig.loadError,
                         parseError: bridgeConfig.parseError,
                         options: bridgeConfig.getRawValues(),
+                        // What modules actually consume; the QA tool reads module configs from here
+                        resolvedOptions: bridgeConfig.getValues(),
                         path: bridgeConfig.path,
                         remoteLoadStatus: bridgeConfig.remoteLoadStatus,
                         remoteLoadError: bridgeConfig.remoteLoadError,

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -41,6 +41,10 @@ import {
 import { LEADERBOARD_TYPE, type LeaderboardType } from '../modules/leaderboards/constants'
 import type { NormalizedAchievement } from '../modules/achievements/types'
 import type { CrossPromoShownPayload } from '../modules/cross-promo/types'
+import type {
+    DailyRewardsClaimedPayload,
+    DailyRewardsStreakResetPayload,
+} from '../modules/daily-rewards/types'
 import type { AnyRecord } from '../utils'
 import type { SafeAreaInsets } from '../lib/safe-area'
 
@@ -80,6 +84,10 @@ export const ACTION_NAME_QA = {
     SHOW_ADVANCED_BANNERS: 'show_advanced_banners',
     HIDE_ADVANCED_BANNERS: 'hide_advanced_banners',
     CROSS_PROMO_SHOWN: 'cross_promo_shown',
+    // Outbound notifications (events that already happened), not commands:
+    // the imperative daily_rewards_* names stay free for future QA tool commands.
+    DAILY_REWARDS_CLAIMED: 'daily_rewards_claimed',
+    DAILY_REWARDS_STREAK_RESET: 'daily_rewards_streak_reset',
 } as const
 export type ActionNameQa = typeof ACTION_NAME_QA[keyof typeof ACTION_NAME_QA]
 
@@ -310,6 +318,20 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 this.#sendMessage({
                     type: MODULE_NAME.CROSS_PROMO,
                     action: ACTION_NAME_QA.CROSS_PROMO_SHOWN,
+                    options: { ...payload },
+                })
+            })
+            this.on(EVENT_NAME.DAILY_REWARDS_CLAIMED, (payload: DailyRewardsClaimedPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.DAILY_REWARDS,
+                    action: ACTION_NAME_QA.DAILY_REWARDS_CLAIMED,
+                    options: { ...payload },
+                })
+            })
+            this.on(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, (payload: DailyRewardsStreakResetPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.DAILY_REWARDS,
+                    action: ACTION_NAME_QA.DAILY_REWARDS_STREAK_RESET,
                     options: { ...payload },
                 })
             })

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -321,14 +321,14 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                     options: { ...payload },
                 })
             })
-            this.on(EVENT_NAME.DAILY_REWARDS_CLAIMED, (payload: DailyRewardsClaimedPayload) => {
+            eventBus.on(EVENT_NAME.DAILY_REWARDS_CLAIMED, (payload: DailyRewardsClaimedPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.DAILY_REWARDS,
                     action: ACTION_NAME_QA.DAILY_REWARDS_CLAIMED,
                     options: { ...payload },
                 })
             })
-            this.on(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, (payload: DailyRewardsStreakResetPayload) => {
+            eventBus.on(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, (payload: DailyRewardsStreakResetPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.DAILY_REWARDS,
                     action: ACTION_NAME_QA.DAILY_REWARDS_STREAK_RESET,

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -341,14 +341,14 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                     options: { ...payload },
                 })
             })
-            this.on(EVENT_NAME.TASKS_REWARD_CLAIMED, (payload: TasksRewardClaimedPayload) => {
+            eventBus.on(EVENT_NAME.TASKS_REWARD_CLAIMED, (payload: TasksRewardClaimedPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.TASKS,
                     action: ACTION_NAME_QA.TASKS_REWARD_CLAIMED,
                     options: { ...payload },
                 })
             })
-            this.on(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, (payload: TasksPeriodRolledOverPayload) => {
+            eventBus.on(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, (payload: TasksPeriodRolledOverPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.TASKS,
                     action: ACTION_NAME_QA.TASKS_PERIOD_ROLLED_OVER,

--- a/tests/src/modules/dailyRewardsModule.spec.ts
+++ b/tests/src/modules/dailyRewardsModule.spec.ts
@@ -1,0 +1,189 @@
+import {
+    describe, test, expect, vi, beforeEach,
+} from 'vitest'
+import DailyRewardsModule from '../../../src/modules/daily-rewards/DailyRewardsModule'
+import bridgeConfig from '../../../src/lib/bridge-config'
+import { MS_PER_DAY } from '../../../src/modules/daily-rewards/constants'
+import { EVENT_NAME } from '../../../src/constants'
+import type { DailyRewardsBridgeContract } from '../../../src/modules/daily-rewards/types'
+
+const { store } = vi.hoisted(() => ({ store: new Map<string, unknown>() }))
+
+vi.mock('../../../src/modules/storage', () => ({
+    default: {
+        get: vi.fn((key: string) => Promise.resolve(
+            store.has(key) ? JSON.parse(JSON.stringify(store.get(key))) : null,
+        )),
+        set: vi.fn((key: string, value: unknown) => {
+            store.set(key, JSON.parse(JSON.stringify(value)))
+            return Promise.resolve()
+        }),
+    },
+}))
+
+vi.mock('../../../src/lib/bridge-config', () => ({
+    default: {
+        getValues: vi.fn(() => ({})),
+    },
+}))
+
+const BASE_MS = 100 * MS_PER_DAY
+
+// A bridge with a movable server clock and a spied event emitter.
+function createBridge() {
+    const clock = { ms: BASE_MS }
+    return {
+        platformId: 'mock',
+        getServerTime: vi.fn(() => Promise.resolve(clock.ms)),
+        emit: vi.fn(),
+        clock,
+    }
+}
+
+function createModule(bridge: ReturnType<typeof createBridge>) {
+    return new DailyRewardsModule().initialize(bridge as unknown as DailyRewardsBridgeContract)
+}
+
+function emitted(bridge: ReturnType<typeof createBridge>, eventName: string) {
+    return bridge.emit.mock.calls.filter(([name]) => name === eventName)
+}
+
+describe('DailyRewardsModule', () => {
+    beforeEach(() => {
+        store.clear()
+        vi.mocked(bridgeConfig.getValues).mockReturnValue({
+            dailyRewards: { rewards: ['a', 'b', 'c'] },
+        })
+    })
+
+    test('successful claim emits the claimed event', async () => {
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(bridge.emit).toHaveBeenCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 0, reward: 'a' },
+        )
+    })
+
+    test('same-day repeated claim is rejected and does not emit', async () => {
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        await module.claimCurrentReward()
+        expect(await module.claimCurrentReward()).toBe(false)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+    })
+
+    test('missed-day reset emits the streak reset event', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+
+        bridge.clock.ms += 3 * MS_PER_DAY
+        const module = createModule(bridge)
+
+        expect(await module.getCurrentDay()).toBe(0)
+        expect(bridge.emit).toHaveBeenCalledWith(
+            EVENT_NAME.DAILY_REWARDS_STREAK_RESET,
+            { day: 1 },
+        )
+    })
+
+    test('concurrent claims grant a single reward', async () => {
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        const results = await Promise.all([
+            module.claimCurrentReward(),
+            module.claimCurrentReward(),
+        ])
+
+        expect(results.filter(Boolean)).toHaveLength(1)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+        expect(await module.getCurrentDay()).toBe(1)
+    })
+
+    test('concurrent refreshes emit a single reset', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+
+        bridge.clock.ms += 3 * MS_PER_DAY
+        const module = createModule(bridge)
+
+        await Promise.all([module.getCurrentDay(), module.getCurrentReward()])
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+    })
+
+    test('claim racing a missed-day reset claims the first day', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+
+        bridge.clock.ms += 3 * MS_PER_DAY
+        const module = createModule(bridge)
+
+        const [, claimed] = await Promise.all([
+            module.getCurrentDay(),
+            module.claimCurrentReward(),
+        ])
+
+        expect(claimed).toBe(true)
+        expect(bridge.emit).toHaveBeenCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 0, reward: 'a' },
+        )
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+    })
+
+    test('single reward with cycle relies on the claim date alone', async () => {
+        vi.mocked(bridgeConfig.getValues).mockReturnValue({
+            dailyRewards: { rewards: ['a'] },
+        })
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(await module.getCurrentDay()).toBe(0)
+        expect(await module.claimCurrentReward()).toBe(false)
+
+        bridge.clock.ms += MS_PER_DAY
+        expect(await createModule(bridge).claimCurrentReward()).toBe(true)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+    })
+
+    test('claiming the last reward wraps to the first day when cycle is on', async () => {
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+        bridge.clock.ms += MS_PER_DAY
+        await createModule(bridge).claimCurrentReward()
+        bridge.clock.ms += MS_PER_DAY
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(bridge.emit).toHaveBeenLastCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 2, reward: 'c' },
+        )
+        expect(await module.getCurrentDay()).toBe(0)
+    })
+
+    test('claims stop after the last reward when cycle is off', async () => {
+        vi.mocked(bridgeConfig.getValues).mockReturnValue({
+            dailyRewards: { rewards: ['a', 'b'], cycle: false },
+        })
+        const bridge = createBridge()
+        await createModule(bridge).claimCurrentReward()
+        bridge.clock.ms += MS_PER_DAY
+        const module = createModule(bridge)
+
+        expect(await module.claimCurrentReward()).toBe(true)
+        expect(bridge.emit).toHaveBeenLastCalledWith(
+            EVENT_NAME.DAILY_REWARDS_CLAIMED,
+            { day: 1, reward: 'b' },
+        )
+
+        bridge.clock.ms += MS_PER_DAY
+        expect(await createModule(bridge).claimCurrentReward()).toBe(false)
+        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+    })
+})

--- a/tests/src/modules/dailyRewardsModule.spec.ts
+++ b/tests/src/modules/dailyRewardsModule.spec.ts
@@ -2,6 +2,7 @@ import {
     describe, test, expect, vi, beforeEach,
 } from 'vitest'
 import DailyRewardsModule from '../../../src/modules/daily-rewards/DailyRewardsModule'
+import eventBus from '../../../src/lib/EventBus'
 import bridgeConfig from '../../../src/lib/bridge-config'
 import { MS_PER_DAY } from '../../../src/modules/daily-rewards/constants'
 import { EVENT_NAME } from '../../../src/constants'
@@ -29,28 +30,31 @@ vi.mock('../../../src/lib/bridge-config', () => ({
 
 const BASE_MS = 100 * MS_PER_DAY
 
-// A bridge with a movable server clock and a spied event emitter.
+// A bridge with a movable server clock. Events are emitted on the global
+// event bus, not on the bridge, so the bus emit is spied instead.
 function createBridge() {
     const clock = { ms: BASE_MS }
     return {
         platformId: 'mock',
         getServerTime: vi.fn(() => Promise.resolve(clock.ms)),
-        emit: vi.fn(),
         clock,
     }
 }
+
+const busEmit = vi.spyOn(eventBus, 'emit')
 
 function createModule(bridge: ReturnType<typeof createBridge>) {
     return new DailyRewardsModule().initialize(bridge as unknown as DailyRewardsBridgeContract)
 }
 
-function emitted(bridge: ReturnType<typeof createBridge>, eventName: string) {
-    return bridge.emit.mock.calls.filter(([name]) => name === eventName)
+function emitted(eventName: string) {
+    return busEmit.mock.calls.filter(([name]) => name === eventName)
 }
 
 describe('DailyRewardsModule', () => {
     beforeEach(() => {
         store.clear()
+        busEmit.mockClear()
         vi.mocked(bridgeConfig.getValues).mockReturnValue({
             dailyRewards: { rewards: ['a', 'b', 'c'] },
         })
@@ -61,7 +65,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.claimCurrentReward()).toBe(true)
-        expect(bridge.emit).toHaveBeenCalledWith(
+        expect(busEmit).toHaveBeenCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 0, reward: 'a' },
         )
@@ -73,7 +77,7 @@ describe('DailyRewardsModule', () => {
 
         await module.claimCurrentReward()
         expect(await module.claimCurrentReward()).toBe(false)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
     })
 
     test('missed-day reset emits the streak reset event', async () => {
@@ -84,7 +88,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.getCurrentDay()).toBe(0)
-        expect(bridge.emit).toHaveBeenCalledWith(
+        expect(busEmit).toHaveBeenCalledWith(
             EVENT_NAME.DAILY_REWARDS_STREAK_RESET,
             { day: 1 },
         )
@@ -100,7 +104,7 @@ describe('DailyRewardsModule', () => {
         ])
 
         expect(results.filter(Boolean)).toHaveLength(1)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(1)
         expect(await module.getCurrentDay()).toBe(1)
     })
 
@@ -112,7 +116,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         await Promise.all([module.getCurrentDay(), module.getCurrentReward()])
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
     })
 
     test('claim racing a missed-day reset claims the first day', async () => {
@@ -128,11 +132,11 @@ describe('DailyRewardsModule', () => {
         ])
 
         expect(claimed).toBe(true)
-        expect(bridge.emit).toHaveBeenCalledWith(
+        expect(busEmit).toHaveBeenCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 0, reward: 'a' },
         )
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)).toHaveLength(1)
     })
 
     test('single reward with cycle relies on the claim date alone', async () => {
@@ -148,7 +152,7 @@ describe('DailyRewardsModule', () => {
 
         bridge.clock.ms += MS_PER_DAY
         expect(await createModule(bridge).claimCurrentReward()).toBe(true)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
     })
 
     test('claiming the last reward wraps to the first day when cycle is on', async () => {
@@ -160,7 +164,7 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.claimCurrentReward()).toBe(true)
-        expect(bridge.emit).toHaveBeenLastCalledWith(
+        expect(busEmit).toHaveBeenLastCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 2, reward: 'c' },
         )
@@ -177,13 +181,13 @@ describe('DailyRewardsModule', () => {
         const module = createModule(bridge)
 
         expect(await module.claimCurrentReward()).toBe(true)
-        expect(bridge.emit).toHaveBeenLastCalledWith(
+        expect(busEmit).toHaveBeenLastCalledWith(
             EVENT_NAME.DAILY_REWARDS_CLAIMED,
             { day: 1, reward: 'b' },
         )
 
         bridge.clock.ms += MS_PER_DAY
         expect(await createModule(bridge).claimCurrentReward()).toBe(false)
-        expect(emitted(bridge, EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
+        expect(emitted(EVENT_NAME.DAILY_REWARDS_CLAIMED)).toHaveLength(2)
     })
 })

--- a/tests/src/modules/tasksModule.spec.ts
+++ b/tests/src/modules/tasksModule.spec.ts
@@ -2,6 +2,7 @@ import {
     describe, test, expect, vi, beforeEach,
 } from 'vitest'
 import TasksModule from '../../../src/modules/tasks/TasksModule'
+import eventBus from '../../../src/lib/EventBus'
 import bridgeConfig from '../../../src/lib/bridge-config'
 import { EVENT_NAME } from '../../../src/constants'
 import { MS_PER_DAY, MS_PER_WEEK } from '../../../src/modules/tasks/constants'
@@ -40,17 +41,19 @@ function mockConfig(tasks?: TasksConfig) {
     vi.mocked(bridgeConfig.getValues).mockReturnValue(tasks ? { tasks } : {})
 }
 
-// A bridge whose server time can be moved to drive roll-over.
+// A bridge whose server time can be moved to drive roll-over. Events are
+// emitted on the global event bus, not on the bridge, so the bus emit is spied.
 function createBridge(ms = BASE_MS) {
     const clock = { ms }
     const bridge = {
         platformId: 'mock',
         getServerTime: vi.fn(() => Promise.resolve(clock.ms)),
-        emit: vi.fn(),
         clock,
     }
     return bridge
 }
+
+const busEmit = vi.spyOn(eventBus, 'emit')
 
 function createModule(bridge: ReturnType<typeof createBridge>) {
     return new TasksModule().initialize(bridge as unknown as TasksBridgeContract)
@@ -81,6 +84,7 @@ function find(tasks: Awaited<ReturnType<TasksModule['getTasks']>>, id: string) {
 describe('TasksModule', () => {
     beforeEach(() => {
         store.clear()
+        busEmit.mockClear()
         mockConfig(undefined)
     })
 
@@ -246,7 +250,7 @@ describe('TasksModule', () => {
 
             await module.claimReward('kills')
 
-            expect(bridge.emit).toHaveBeenCalledWith(EVENT_NAME.TASKS_REWARD_CLAIMED, {
+            expect(busEmit).toHaveBeenCalledWith(EVENT_NAME.TASKS_REWARD_CLAIMED, {
                 taskId: 'kills',
                 groupId: 'daily',
                 type: 'daily',
@@ -260,13 +264,13 @@ describe('TasksModule', () => {
             const module = createModule(bridge)
 
             await module.claimReward('kills') // incomplete
-            expect(bridge.emit).not.toHaveBeenCalled()
+            expect(busEmit).not.toHaveBeenCalled()
 
             await module.addProgress('enemy_killed', 20)
             await module.claimReward('kills')
-            bridge.emit.mockClear()
+            busEmit.mockClear()
             await module.claimReward('kills') // repeated
-            expect(bridge.emit).not.toHaveBeenCalled()
+            expect(busEmit).not.toHaveBeenCalled()
         })
 
         test('the very first sync of a group is a start, not a roll-over', async () => {
@@ -275,7 +279,7 @@ describe('TasksModule', () => {
 
             await createModule(bridge).getTasks()
 
-            expect(bridge.emit).not.toHaveBeenCalled()
+            expect(busEmit).not.toHaveBeenCalled()
         })
 
         test('a daily period change emits the roll-over event with both period keys', async () => {
@@ -287,7 +291,7 @@ describe('TasksModule', () => {
             bridge.clock.ms += MS_PER_DAY
             await module.getTasks()
 
-            expect(bridge.emit).toHaveBeenCalledWith(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, {
+            expect(busEmit).toHaveBeenCalledWith(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, {
                 groupId: 'daily',
                 type: 'daily',
                 periodKey: 101,
@@ -303,11 +307,11 @@ describe('TasksModule', () => {
 
             bridge.clock.ms += MS_PER_DAY
             await module.getTasks()
-            expect(bridge.emit).not.toHaveBeenCalled()
+            expect(busEmit).not.toHaveBeenCalled()
 
             bridge.clock.ms += MS_PER_WEEK
             await module.getTasks()
-            expect(bridge.emit).toHaveBeenCalledWith(
+            expect(busEmit).toHaveBeenCalledWith(
                 EVENT_NAME.TASKS_PERIOD_ROLLED_OVER,
                 expect.objectContaining({ groupId: 'weekly', type: 'weekly' }),
             )
@@ -322,7 +326,7 @@ describe('TasksModule', () => {
             bridge.clock.ms += 30 * MS_PER_DAY
             await module.getTasks()
 
-            expect(bridge.emit).not.toHaveBeenCalled()
+            expect(busEmit).not.toHaveBeenCalled()
         })
     })
 

--- a/tests/src/modules/tasksModule.spec.ts
+++ b/tests/src/modules/tasksModule.spec.ts
@@ -3,6 +3,7 @@ import {
 } from 'vitest'
 import TasksModule from '../../../src/modules/tasks/TasksModule'
 import bridgeConfig from '../../../src/lib/bridge-config'
+import { EVENT_NAME } from '../../../src/constants'
 import { MS_PER_DAY, MS_PER_WEEK } from '../../../src/modules/tasks/constants'
 import type {
     TasksBridgeContract,
@@ -45,6 +46,7 @@ function createBridge(ms = BASE_MS) {
     const bridge = {
         platformId: 'mock',
         getServerTime: vi.fn(() => Promise.resolve(clock.ms)),
+        emit: vi.fn(),
         clock,
     }
     return bridge
@@ -232,6 +234,95 @@ describe('TasksModule', () => {
 
             const kills = find(await createModule(createBridge()).getTasks(), 'kills')
             expect(kills.targets[0].progress).toBe(7)
+        })
+    })
+
+    describe('events', () => {
+        test('a successful claim emits the reward claimed event with the task rewards', async () => {
+            mockConfig(DAILY_CONFIG)
+            const bridge = createBridge()
+            const module = createModule(bridge)
+            await module.addProgress('enemy_killed', 20)
+
+            await module.claimReward('kills')
+
+            expect(bridge.emit).toHaveBeenCalledWith(EVENT_NAME.TASKS_REWARD_CLAIMED, {
+                taskId: 'kills',
+                groupId: 'daily',
+                type: 'daily',
+                rewards: [{ id: 'gold', amount: 500 }],
+            })
+        })
+
+        test('a rejected claim (incomplete or repeated) emits nothing', async () => {
+            mockConfig(DAILY_CONFIG)
+            const bridge = createBridge()
+            const module = createModule(bridge)
+
+            await module.claimReward('kills') // incomplete
+            expect(bridge.emit).not.toHaveBeenCalled()
+
+            await module.addProgress('enemy_killed', 20)
+            await module.claimReward('kills')
+            bridge.emit.mockClear()
+            await module.claimReward('kills') // repeated
+            expect(bridge.emit).not.toHaveBeenCalled()
+        })
+
+        test('the very first sync of a group is a start, not a roll-over', async () => {
+            mockConfig(DAILY_CONFIG)
+            const bridge = createBridge()
+
+            await createModule(bridge).getTasks()
+
+            expect(bridge.emit).not.toHaveBeenCalled()
+        })
+
+        test('a daily period change emits the roll-over event with both period keys', async () => {
+            mockConfig(DAILY_CONFIG)
+            const bridge = createBridge()
+            const module = createModule(bridge)
+            await module.getTasks()
+
+            bridge.clock.ms += MS_PER_DAY
+            await module.getTasks()
+
+            expect(bridge.emit).toHaveBeenCalledWith(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, {
+                groupId: 'daily',
+                type: 'daily',
+                periodKey: 101,
+                previousPeriodKey: 100,
+            })
+        })
+
+        test('a weekly group does not roll over after a day, only after a week', async () => {
+            mockConfig([{ id: 'weekly', type: 'weekly', items: [{ id: 'wk', targets: [{ id: 'm', amount: 5 }], rewards: [] }] }])
+            const bridge = createBridge()
+            const module = createModule(bridge)
+            await module.getTasks()
+
+            bridge.clock.ms += MS_PER_DAY
+            await module.getTasks()
+            expect(bridge.emit).not.toHaveBeenCalled()
+
+            bridge.clock.ms += MS_PER_WEEK
+            await module.getTasks()
+            expect(bridge.emit).toHaveBeenCalledWith(
+                EVENT_NAME.TASKS_PERIOD_ROLLED_OVER,
+                expect.objectContaining({ groupId: 'weekly', type: 'weekly' }),
+            )
+        })
+
+        test('a permanent group never rolls over', async () => {
+            mockConfig([{ id: 'perm', type: 'permanent', items: [{ id: 'pm', targets: [{ id: 'm', amount: 5 }], rewards: [] }] }])
+            const bridge = createBridge()
+            const module = createModule(bridge)
+            await module.getTasks()
+
+            bridge.clock.ms += 30 * MS_PER_DAY
+            await module.getTasks()
+
+            expect(bridge.emit).not.toHaveBeenCalled()
         })
     })
 

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -84,4 +84,16 @@ describe('QaToolPlatformBridge modules wire format', () => {
             options: { day: 4 },
         })
     })
+
+    test('initialize payload carries platform-resolved config options', () => {
+        createInitializedBridge()
+
+        const initializeMessage = sendSpy.mock.calls
+            .map(([message]) => message as { action?: string, payload?: Record<string, unknown> })
+            .find((message) => message.action === 'initialize')
+
+        expect(initializeMessage).toBeDefined()
+        const configFile = initializeMessage?.payload?.configFile as Record<string, unknown>
+        expect(configFile.resolvedOptions).toBeDefined()
+    })
 })

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -29,6 +29,8 @@ describe('QaToolPlatformBridge modules wire format', () => {
         sendSpy.mockClear()
         // The bus is a singleton; drop subscriptions left by bridges from
         // previous tests so each test observes exactly one forwarder.
+        eventBus.off(EVENT_NAME.DAILY_REWARDS_CLAIMED)
+        eventBus.off(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)
         eventBus.off(EVENT_NAME.CROSS_PROMO_SHOWN)
     })
 
@@ -60,9 +62,9 @@ describe('QaToolPlatformBridge modules wire format', () => {
     })
 
     test('claimed event is forwarded as a daily_rewards_claimed message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, { day: 2, reward: 'gem' })
+        eventBus.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, { day: 2, reward: 'gem' })
 
         expect(sendSpy).toHaveBeenLastCalledWith({
             source: 'bridge',
@@ -73,9 +75,9 @@ describe('QaToolPlatformBridge modules wire format', () => {
     })
 
     test('streak reset event is forwarded as a daily_rewards_streak_reset message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, { day: 4 })
+        eventBus.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, { day: 4 })
 
         expect(sendSpy).toHaveBeenLastCalledWith({
             source: 'bridge',

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -31,6 +31,8 @@ describe('QaToolPlatformBridge modules wire format', () => {
         // previous tests so each test observes exactly one forwarder.
         eventBus.off(EVENT_NAME.DAILY_REWARDS_CLAIMED)
         eventBus.off(EVENT_NAME.DAILY_REWARDS_STREAK_RESET)
+        eventBus.off(EVENT_NAME.TASKS_REWARD_CLAIMED)
+        eventBus.off(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER)
         eventBus.off(EVENT_NAME.CROSS_PROMO_SHOWN)
     })
 
@@ -100,9 +102,9 @@ describe('QaToolPlatformBridge modules wire format', () => {
     })
 
     test('reward claimed event is forwarded as a tasks_reward_claimed message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.TASKS_REWARD_CLAIMED, {
+        eventBus.emit(EVENT_NAME.TASKS_REWARD_CLAIMED, {
             taskId: 'kills',
             groupId: 'daily',
             type: 'daily',
@@ -123,9 +125,9 @@ describe('QaToolPlatformBridge modules wire format', () => {
     })
 
     test('period roll-over event is forwarded as a tasks_period_rolled_over message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, {
+        eventBus.emit(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, {
             groupId: 'daily',
             type: 'daily',
             periodKey: 101,

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -24,7 +24,7 @@ vi.stubGlobal('PLUGIN_VERSION', 'test-version')
 // Pins the outbound wire format consumed by the external QA tool. The literals
 // are intentional: renaming a constant must break this test, not silently
 // change the protocol.
-describe('QaToolPlatformBridge cross promo wire format', () => {
+describe('QaToolPlatformBridge modules wire format', () => {
     beforeEach(() => {
         sendSpy.mockClear()
         // The bus is a singleton; drop subscriptions left by bridges from
@@ -56,6 +56,32 @@ describe('QaToolPlatformBridge cross promo wire format', () => {
                 source: 'config',
                 games: [{ url: 'https://example.com/pixel-run', name: 'Pixel Run' }],
             },
+        })
+    })
+
+    test('claimed event is forwarded as a daily_rewards_claimed message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.DAILY_REWARDS_CLAIMED, { day: 2, reward: 'gem' })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'daily_rewards',
+            action: 'daily_rewards_claimed',
+            options: { day: 2, reward: 'gem' },
+        })
+    })
+
+    test('streak reset event is forwarded as a daily_rewards_streak_reset message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.DAILY_REWARDS_STREAK_RESET, { day: 4 })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'daily_rewards',
+            action: 'daily_rewards_streak_reset',
+            options: { day: 4 },
         })
     })
 })

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -98,4 +98,50 @@ describe('QaToolPlatformBridge modules wire format', () => {
         const configFile = initializeMessage?.payload?.configFile as Record<string, unknown>
         expect(configFile.resolvedOptions).toBeDefined()
     })
+
+    test('reward claimed event is forwarded as a tasks_reward_claimed message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.TASKS_REWARD_CLAIMED, {
+            taskId: 'kills',
+            groupId: 'daily',
+            type: 'daily',
+            rewards: [{ id: 'gold', amount: 500 }],
+        })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'tasks',
+            action: 'tasks_reward_claimed',
+            options: {
+                taskId: 'kills',
+                groupId: 'daily',
+                type: 'daily',
+                rewards: [{ id: 'gold', amount: 500 }],
+            },
+        })
+    })
+
+    test('period roll-over event is forwarded as a tasks_period_rolled_over message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.TASKS_PERIOD_ROLLED_OVER, {
+            groupId: 'daily',
+            type: 'daily',
+            periodKey: 101,
+            previousPeriodKey: 100,
+        })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'tasks',
+            action: 'tasks_period_rolled_over',
+            options: {
+                groupId: 'daily',
+                type: 'daily',
+                periodKey: 101,
+                previousPeriodKey: 100,
+            },
+        })
+    })
 })


### PR DESCRIPTION
## Summary

- add `EVENT_NAME.TASKS_REWARD_CLAIMED` / `TASKS_PERIOD_ROLLED_OVER` with named
  payload types
- `claimReward()` emits the claimed event after a successful persist (task id,
  group id, group type, reward list)
- `#sync()` emits the roll-over event only when a stored period is replaced;
  the very first sync of a group stays silent
- events go through the global event bus, so the public `bridge.on()` receives them
- `QaToolPlatformBridge` forwards both events to the external QA tool via
  `ACTION_NAME_QA` (`tasks_reward_claimed` / `tasks_period_rolled_over`)
- tests: claim emits with rewards, rejected/repeated claim emits nothing, first
  sync emits nothing, daily/weekly/permanent roll-over timing; wire format pinned
  in `qaToolPlatformBridge.spec.ts`

Module mechanics (progress, claim rules, periods) and the package version are unchanged.

## Validation

- `npm test` (109 tests)
- `npm run lint`
- `npm run build`
- `npm run build:types`