### PR TITLE
QA-tool cross promo events

### DIFF
--- a/src/constants/eventName.ts
+++ b/src/constants/eventName.ts
@@ -28,5 +28,6 @@ export const EVENT_NAME = {
     PLATFORM_STORAGE_AVAILABILITY_CHANGED: 'platform_storage_availability_changed',
     VISIBILITY_STATE_CHANGED: 'visibility_state_changed',
     STORAGE_SET: 'storage_set',
+    CROSS_PROMO_SHOWN: 'cross_promo_shown',
 } as const
 export type EventName = typeof EVENT_NAME[keyof typeof EVENT_NAME]

--- a/src/modules/cross-promo/CrossPromoModule.ts
+++ b/src/modules/cross-promo/CrossPromoModule.ts
@@ -39,6 +39,7 @@ import type {
     CrossPromoConfig,
     Game,
     CrossPromoBridgeContract,
+    CrossPromoShownPayload,
 } from './types'
 
 class CrossPromoModule extends ModuleBase<CrossPromoBridgeContract> {
@@ -90,6 +91,9 @@ class CrossPromoModule extends ModuleBase<CrossPromoBridgeContract> {
         this.#injectStyles()
         this.#container = this.#createContainer(selectedGames, this.#getConfig().title)
         document.body.appendChild(this.#container)
+
+        const payload: CrossPromoShownPayload = { source: this.#source, games: selectedGames }
+        this._platformBridge.emit(EVENT_NAME.CROSS_PROMO_SHOWN, payload)
     }
 
     hide(): void {

--- a/src/modules/cross-promo/CrossPromoModule.ts
+++ b/src/modules/cross-promo/CrossPromoModule.ts
@@ -93,7 +93,7 @@ class CrossPromoModule extends ModuleBase<CrossPromoBridgeContract> {
         document.body.appendChild(this.#container)
 
         const payload: CrossPromoShownPayload = { source: this.#source, games: selectedGames }
-        this._platformBridge.emit(EVENT_NAME.CROSS_PROMO_SHOWN, payload)
+        eventBus.emit(EVENT_NAME.CROSS_PROMO_SHOWN, payload)
     }
 
     hide(): void {

--- a/src/modules/cross-promo/types.ts
+++ b/src/modules/cross-promo/types.ts
@@ -47,7 +47,7 @@ export interface CrossPromoConfig {
     games?: CrossPromoGame[]
 }
 
-// Payload of the cross promo event emitted on the platform bridge
+// Payload of the cross promo event emitted on the global event bus
 // (EVENT_NAME.CROSS_PROMO_SHOWN): the games actually rendered in the overlay.
 export interface CrossPromoShownPayload {
     source: CrossPromoSource

--- a/src/modules/cross-promo/types.ts
+++ b/src/modules/cross-promo/types.ts
@@ -47,6 +47,13 @@ export interface CrossPromoConfig {
     games?: CrossPromoGame[]
 }
 
+// Payload of the cross promo event emitted on the platform bridge
+// (EVENT_NAME.CROSS_PROMO_SHOWN): the games actually rendered in the overlay.
+export interface CrossPromoShownPayload {
+    source: CrossPromoSource
+    games: Game[]
+}
+
 export interface CrossPromoBridgeContract extends PlatformBridgeLike {
     isPlatformGamesListSupported: boolean
     getGamesList(): Promise<unknown[]>

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -16,6 +16,7 @@
  */
 
 import PlatformBridgeBase from './PlatformBridgeBase'
+import eventBus from '../lib/EventBus'
 import ServerTimeCache from '../lib/ServerTimeCache'
 import MessageBroker from '../lib/MessageBroker'
 import bridgeConfig from '../lib/bridge-config'
@@ -302,7 +303,10 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                     options: { isPaused },
                 })
             })
-            this.on(EVENT_NAME.CROSS_PROMO_SHOWN, (payload: CrossPromoShownPayload) => {
+            // Module-originated events arrive on the global event bus (the bus
+            // the public bridge.on() is wired to), unlike AUDIO/PAUSE above,
+            // which this bridge emits itself.
+            eventBus.on(EVENT_NAME.CROSS_PROMO_SHOWN, (payload: CrossPromoShownPayload) => {
                 this.#sendMessage({
                     type: MODULE_NAME.CROSS_PROMO,
                     action: ACTION_NAME_QA.CROSS_PROMO_SHOWN,

--- a/src/platform-bridges/QaToolPlatformBridge.ts
+++ b/src/platform-bridges/QaToolPlatformBridge.ts
@@ -39,6 +39,7 @@ import {
 } from '../modules/advertisement/constants'
 import { LEADERBOARD_TYPE, type LeaderboardType } from '../modules/leaderboards/constants'
 import type { NormalizedAchievement } from '../modules/achievements/types'
+import type { CrossPromoShownPayload } from '../modules/cross-promo/types'
 import type { AnyRecord } from '../utils'
 import type { SafeAreaInsets } from '../lib/safe-area'
 
@@ -77,6 +78,7 @@ export const ACTION_NAME_QA = {
     CLEAN_CACHE: 'clean_cache',
     SHOW_ADVANCED_BANNERS: 'show_advanced_banners',
     HIDE_ADVANCED_BANNERS: 'hide_advanced_banners',
+    CROSS_PROMO_SHOWN: 'cross_promo_shown',
 } as const
 export type ActionNameQa = typeof ACTION_NAME_QA[keyof typeof ACTION_NAME_QA]
 
@@ -298,6 +300,13 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                     type: MODULE_NAME.PLATFORM,
                     action: ACTION_NAME_QA.PAUSE_STATE,
                     options: { isPaused },
+                })
+            })
+            this.on(EVENT_NAME.CROSS_PROMO_SHOWN, (payload: CrossPromoShownPayload) => {
+                this.#sendMessage({
+                    type: MODULE_NAME.CROSS_PROMO,
+                    action: ACTION_NAME_QA.CROSS_PROMO_SHOWN,
+                    options: { ...payload },
                 })
             })
 

--- a/tests/src/modules/crossPromoModule.spec.ts
+++ b/tests/src/modules/crossPromoModule.spec.ts
@@ -1,0 +1,97 @@
+import {
+    describe, test, expect, vi, beforeEach,
+} from 'vitest'
+import CrossPromoModule from '../../../src/modules/cross-promo/CrossPromoModule'
+import bridgeConfig from '../../../src/lib/bridge-config'
+import { EVENT_NAME } from '../../../src/constants'
+import { CONTAINER_ID } from '../../../src/modules/cross-promo/constants'
+import type { CrossPromoBridgeContract, CrossPromoConfig } from '../../../src/modules/cross-promo/types'
+
+vi.mock('../../../src/lib/bridge-config', () => ({
+    default: {
+        getValues: vi.fn(() => ({})),
+    },
+}))
+
+function mockConfig(crossPromo?: CrossPromoConfig) {
+    vi.mocked(bridgeConfig.getValues).mockReturnValue(crossPromo ? { crossPromo } : {})
+}
+
+function createBridge() {
+    return {
+        platformId: 'mock',
+        isPlatformGamesListSupported: false,
+        getGamesList: vi.fn(() => Promise.resolve([])),
+        emit: vi.fn(),
+    }
+}
+
+function createModule(bridge: ReturnType<typeof createBridge>) {
+    return new CrossPromoModule().initialize(bridge as unknown as CrossPromoBridgeContract)
+}
+
+const CONFIG: CrossPromoConfig = {
+    title: 'More games',
+    games: [
+        { url: 'https://example.com/pixel-run', name: 'Pixel Run' },
+        { url: 'https://example.com/space-bit' },
+    ],
+}
+
+describe('CrossPromoModule events', () => {
+    beforeEach(() => {
+        mockConfig(undefined)
+        document.getElementById(CONTAINER_ID)?.remove()
+    })
+
+    test('show renders the overlay and emits the shown event with the rendered games', async () => {
+        mockConfig(CONFIG)
+        const bridge = createBridge()
+
+        await createModule(bridge).show()
+
+        expect(document.getElementById(CONTAINER_ID)).not.toBeNull()
+        expect(bridge.emit).toHaveBeenCalledTimes(1)
+
+        const [eventName, payload] = bridge.emit.mock.calls[0]
+        expect(eventName).toBe(EVENT_NAME.CROSS_PROMO_SHOWN)
+        expect(payload.source).toBe('config')
+        expect(payload.games.map((game: { url: string }) => game.url).sort()).toEqual([
+            'https://example.com/pixel-run',
+            'https://example.com/space-bit',
+        ])
+    })
+
+    test('show without a renderable games list renders nothing and emits nothing', async () => {
+        mockConfig({ games: [] })
+        const bridge = createBridge()
+
+        await createModule(bridge).show()
+
+        expect(document.getElementById(CONTAINER_ID)).toBeNull()
+        expect(bridge.emit).not.toHaveBeenCalled()
+    })
+
+    test('a second show while the overlay is visible emits nothing new', async () => {
+        mockConfig(CONFIG)
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        await module.show()
+        await module.show()
+
+        expect(bridge.emit).toHaveBeenCalledTimes(1)
+    })
+
+    test('show after hide emits again', async () => {
+        mockConfig(CONFIG)
+        const bridge = createBridge()
+        const module = createModule(bridge)
+
+        await module.show()
+        module.hide()
+        await module.show()
+
+        expect(bridge.emit).toHaveBeenCalledTimes(2)
+    })
+})

--- a/tests/src/modules/crossPromoModule.spec.ts
+++ b/tests/src/modules/crossPromoModule.spec.ts
@@ -2,6 +2,7 @@ import {
     describe, test, expect, vi, beforeEach,
 } from 'vitest'
 import CrossPromoModule from '../../../src/modules/cross-promo/CrossPromoModule'
+import eventBus from '../../../src/lib/EventBus'
 import bridgeConfig from '../../../src/lib/bridge-config'
 import { EVENT_NAME } from '../../../src/constants'
 import { CONTAINER_ID } from '../../../src/modules/cross-promo/constants'
@@ -17,14 +18,17 @@ function mockConfig(crossPromo?: CrossPromoConfig) {
     vi.mocked(bridgeConfig.getValues).mockReturnValue(crossPromo ? { crossPromo } : {})
 }
 
+// Events are emitted on the global event bus, not on the bridge,
+// so the bus emit is spied instead.
 function createBridge() {
     return {
         platformId: 'mock',
         isPlatformGamesListSupported: false,
         getGamesList: vi.fn(() => Promise.resolve([])),
-        emit: vi.fn(),
     }
 }
+
+const busEmit = vi.spyOn(eventBus, 'emit')
 
 function createModule(bridge: ReturnType<typeof createBridge>) {
     return new CrossPromoModule().initialize(bridge as unknown as CrossPromoBridgeContract)
@@ -41,6 +45,7 @@ const CONFIG: CrossPromoConfig = {
 describe('CrossPromoModule events', () => {
     beforeEach(() => {
         mockConfig(undefined)
+        busEmit.mockClear()
         document.getElementById(CONTAINER_ID)?.remove()
     })
 
@@ -51,9 +56,12 @@ describe('CrossPromoModule events', () => {
         await createModule(bridge).show()
 
         expect(document.getElementById(CONTAINER_ID)).not.toBeNull()
-        expect(bridge.emit).toHaveBeenCalledTimes(1)
+        expect(busEmit).toHaveBeenCalledTimes(1)
 
-        const [eventName, payload] = bridge.emit.mock.calls[0]
+        const [eventName, payload] = busEmit.mock.calls[0] as [
+            string,
+            { source: string, games: { url: string }[] },
+        ]
         expect(eventName).toBe(EVENT_NAME.CROSS_PROMO_SHOWN)
         expect(payload.source).toBe('config')
         expect(payload.games.map((game: { url: string }) => game.url).sort()).toEqual([
@@ -69,7 +77,7 @@ describe('CrossPromoModule events', () => {
         await createModule(bridge).show()
 
         expect(document.getElementById(CONTAINER_ID)).toBeNull()
-        expect(bridge.emit).not.toHaveBeenCalled()
+        expect(busEmit).not.toHaveBeenCalled()
     })
 
     test('a second show while the overlay is visible emits nothing new', async () => {
@@ -80,7 +88,7 @@ describe('CrossPromoModule events', () => {
         await module.show()
         await module.show()
 
-        expect(bridge.emit).toHaveBeenCalledTimes(1)
+        expect(busEmit).toHaveBeenCalledTimes(1)
     })
 
     test('show after hide emits again', async () => {
@@ -92,6 +100,6 @@ describe('CrossPromoModule events', () => {
         module.hide()
         await module.show()
 
-        expect(bridge.emit).toHaveBeenCalledTimes(2)
+        expect(busEmit).toHaveBeenCalledTimes(2)
     })
 })

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -2,6 +2,7 @@ import {
     describe, test, expect, vi, beforeEach,
 } from 'vitest'
 import QaToolPlatformBridge from '../../../src/platform-bridges/QaToolPlatformBridge'
+import eventBus from '../../../src/lib/EventBus'
 import { EVENT_NAME } from '../../../src/constants'
 
 const { sendSpy } = vi.hoisted(() => ({ sendSpy: vi.fn() }))
@@ -26,6 +27,9 @@ vi.stubGlobal('PLUGIN_VERSION', 'test-version')
 describe('QaToolPlatformBridge cross promo wire format', () => {
     beforeEach(() => {
         sendSpy.mockClear()
+        // The bus is a singleton; drop subscriptions left by bridges from
+        // previous tests so each test observes exactly one forwarder.
+        eventBus.off(EVENT_NAME.CROSS_PROMO_SHOWN)
     })
 
     function createInitializedBridge() {
@@ -37,9 +41,9 @@ describe('QaToolPlatformBridge cross promo wire format', () => {
     }
 
     test('shown event is forwarded as a cross_promo_shown message', () => {
-        const bridge = createInitializedBridge()
+        createInitializedBridge()
 
-        bridge.emit(EVENT_NAME.CROSS_PROMO_SHOWN, {
+        eventBus.emit(EVENT_NAME.CROSS_PROMO_SHOWN, {
             source: 'config',
             games: [{ url: 'https://example.com/pixel-run', name: 'Pixel Run' }],
         })

--- a/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/qaToolPlatformBridge.spec.ts
@@ -1,0 +1,57 @@
+import {
+    describe, test, expect, vi, beforeEach,
+} from 'vitest'
+import QaToolPlatformBridge from '../../../src/platform-bridges/QaToolPlatformBridge'
+import { EVENT_NAME } from '../../../src/constants'
+
+const { sendSpy } = vi.hoisted(() => ({ sendSpy: vi.fn() }))
+
+vi.mock('../../../src/lib/MessageBroker', () => ({
+    default: class MessageBrokerMock {
+        send = sendSpy
+
+        addListener = vi.fn()
+
+        removeListener = vi.fn()
+
+        generateMessageId = () => 'message-id'
+    },
+}))
+
+vi.stubGlobal('PLUGIN_VERSION', 'test-version')
+
+// Pins the outbound wire format consumed by the external QA tool. The literals
+// are intentional: renaming a constant must break this test, not silently
+// change the protocol.
+describe('QaToolPlatformBridge cross promo wire format', () => {
+    beforeEach(() => {
+        sendSpy.mockClear()
+    })
+
+    function createInitializedBridge() {
+        const bridge = new QaToolPlatformBridge()
+        // Fire-and-forget: the promise settles only when the QA tool answers,
+        // which never happens in this test; the subscriptions are set synchronously.
+        bridge.initialize().catch(() => {})
+        return bridge
+    }
+
+    test('shown event is forwarded as a cross_promo_shown message', () => {
+        const bridge = createInitializedBridge()
+
+        bridge.emit(EVENT_NAME.CROSS_PROMO_SHOWN, {
+            source: 'config',
+            games: [{ url: 'https://example.com/pixel-run', name: 'Pixel Run' }],
+        })
+
+        expect(sendSpy).toHaveBeenLastCalledWith({
+            source: 'bridge',
+            type: 'cross_promo',
+            action: 'cross_promo_shown',
+            options: {
+                source: 'config',
+                games: [{ url: 'https://example.com/pixel-run', name: 'Pixel Run' }],
+            },
+        })
+    })
+})


### PR DESCRIPTION
## Summary

- add `EVENT_NAME.CROSS_PROMO_SHOWN` with a named `CrossPromoShownPayload`
  (source + the games actually rendered)
- `CrossPromoModule.show()` emits the event right after the overlay is appended
  to the DOM; early exits (overlay already open, no renderable games) stay silent
- the event goes through the global event bus, so the public `bridge.on()` receives it
- `QaToolPlatformBridge` forwards it to the external QA tool via
  `ACTION_NAME_QA.CROSS_PROMO_SHOWN`
- tests: show emits with the rendered games, empty list emits nothing, a second
  show while visible emits nothing, show after hide emits again; wire format
  pinned in `qaToolPlatformBridge.spec.ts`

Deliberately out of scope: hidden / game click events and a command channel from
the tool.

Module mechanics (overlay rendering, sources, ad auto-hide) and the package
version are unchanged.

## Validation

- `npm test` (106 tests)
- `npm run lint`
- `npm run build`
- `npm run build:types`