### PR TITLE
Analytics standalone game id v1

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -1,0 +1,24 @@
+name: Release to Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Target channel (S3 folder v<major>/<channel>/)
+        type: choice
+        default: stable
+        options:
+          - stable
+          - latest
+          - dev
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      environment: production
+      channel: ${{ inputs.channel }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET_PRODUCTION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,103 @@
+name: Publish (reusable)
+
+# Reusable workflow: verify -> build -> upload to an S3 bucket.
+# Not triggered directly. Called by staging.yml / production.yml.
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: staging | production (drives the release-branch guard)
+        type: string
+        required: true
+      channel:
+        description: stable | latest | dev (S3 folder v<major>/<channel>/)
+        type: string
+        required: true
+    secrets:
+      AWS_ACCESS_KEY_ID:
+        required: true
+      AWS_SECRET_ACCESS_KEY:
+        required: true
+      S3_BUCKET:
+        required: true
+
+env:
+  AWS_REGION: eu-central-1
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard production to release branches
+        if: ${{ inputs.environment == 'production' && !contains(fromJSON('["main", "develop"]'), github.ref_name) }}
+        run: |
+          echo "::error::production is only allowed from 'main' (v2) or 'develop' (v1), got '${{ github.ref_name }}'."
+          exit 1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+
+  build:
+    needs: verify
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - name: Build artifacts
+        env:
+          BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          if [ -z "${BUCKET}" ]; then
+            echo "::error::S3_BUCKET secret is empty."
+            exit 1
+          fi
+          MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+          PUBLIC_PATH="https://${BUCKET}/v${MAJOR}/${{ inputs.channel }}/"
+          npm run build:dist -- --type=both --public-path="$PUBLIC_PATH"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-publish
+          path: dist/publish/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-publish
+          path: dist/publish
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+      - name: Upload to S3
+        env:
+          BUCKET: ${{ secrets.S3_BUCKET }}
+        run: |
+          if [ -z "${BUCKET}" ]; then
+            echo "::error::S3_BUCKET secret is empty."
+            exit 1
+          fi
+          MAJOR="$(node -p "require('./package.json').version.split('.')[0]")"
+          DEST="v${MAJOR}/${{ inputs.channel }}"
+          echo "Publishing ${{ inputs.environment }}/${{ inputs.channel }} -> s3://***/${DEST}/"
+          aws s3 cp dist/publish/ "s3://${BUCKET}/${DEST}/" \
+            --recursive \
+            --content-type application/javascript \
+            --no-progress
+      # CDN cache purge is intentionally omitted for now.

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,24 @@
+name: Release to Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: Target channel (S3 folder v<major>/<channel>/)
+        type: choice
+        default: dev
+        options:
+          - dev
+          - stable
+          - latest
+
+jobs:
+  publish:
+    uses: ./.github/workflows/publish.yml
+    with:
+      environment: staging
+      channel: ${{ inputs.channel }}
+    secrets:
+      AWS_ACCESS_KEY_ID: ${{ secrets.BRIDGE_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.BRIDGE_AWS_SECRET_ACCESS_KEY }}
+      S3_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "build:bundled": "webpack --config-name bundled",
         "build:nolint": "webpack --config-name bundled --env noLint",
         "build:platform": "node scripts/build-platform.js",
+        "build:dist": "node scripts/build-dist.js",
         "develop": "webpack --mode=development",
         "dev": "webpack serve --mode=development --config-name dynamic",
         "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playgama-bridge",
-    "version": "1.31.2",
+    "version": "1.31.3",
     "description": "One SDK for cross-platform publishing HTML5 games",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "playgama-bridge",
-    "version": "1.31.3",
+    "version": "1.31.4",
     "description": "One SDK for cross-platform publishing HTML5 games",
     "main": "index.js",
     "scripts": {
@@ -19,14 +19,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/playgama/bridge"
+        "url": "git+https://github.com/Playgama/bridge"
     },
     "author": "Playgama",
     "license": "LGPL-3.0-or-later",
     "bugs": {
-        "url": "https://github.com/playgama/bridge/issues"
+        "url": "https://github.com/Playgama/bridge/issues"
     },
-    "homepage": "https://github.com/playgama/bridge",
+    "homepage": "https://github.com/Playgama/bridge",
     "dependencies": {},
     "devDependencies": {
         "@babel/core": "^7.17.8",

--- a/scripts/build-dist.js
+++ b/scripts/build-dist.js
@@ -1,0 +1,105 @@
+const { execSync } = require('child_process')
+const fs = require('fs')
+const path = require('path')
+const { ALL_PLATFORM_IDS } = require('./platforms')
+
+const DIST_DIR = path.resolve(__dirname, '../dist')
+const OUT_DIR = path.join(DIST_DIR, 'publish')
+const BUILT_FILE = path.join(DIST_DIR, 'playgama-bridge.js')
+const CHUNKS_DIR = path.join(DIST_DIR, 'platform-bridges')
+
+const args = process.argv.slice(2)
+
+const getArg = (name) => {
+    const prefix = `--${name}=`
+    const arg = args.find((a) => a.startsWith(prefix))
+    return arg ? arg.slice(prefix.length) : undefined
+}
+
+if (args.includes('--help') || args.includes('--list')) {
+    console.info('Usage: node scripts/build-dist.js [--type=both|dynamic|standalone] [--platform=<id>] [--public-path=<url>]')
+    console.info('Available platforms:', ALL_PLATFORM_IDS.join(', '))
+    process.exit(0)
+}
+
+// Absolute URL the dynamic bundle uses to fetch its platform-bridges/ chunks.
+// Should match the deploy location, e.g. https://<domain>/v<major>/<channel>/
+const publicPath = getArg('public-path')
+
+const type = getArg('type') || 'both'
+if (!['both', 'dynamic', 'standalone'].includes(type)) {
+    console.error(`Unknown type: ${type}. Use one of: both, dynamic, standalone`)
+    process.exit(1)
+}
+
+const singlePlatform = getArg('platform')
+if (singlePlatform && !ALL_PLATFORM_IDS.includes(singlePlatform)) {
+    console.error(`Unknown platform: ${singlePlatform}`)
+    console.error(`Available: ${ALL_PLATFORM_IDS.join(', ')}`)
+    process.exit(1)
+}
+
+const run = (command) => {
+    console.info(`\n$ ${command}`)
+    execSync(command, { stdio: 'inherit' })
+}
+
+const ensureBuilt = () => {
+    if (!fs.existsSync(BUILT_FILE)) {
+        console.error(`Expected build output not found: ${BUILT_FILE}`)
+        process.exit(1)
+    }
+}
+
+const collect = (src, relDest) => {
+    const dest = path.join(OUT_DIR, relDest)
+    fs.mkdirSync(path.dirname(dest), { recursive: true })
+    fs.copyFileSync(src, dest)
+    const { size } = fs.statSync(dest)
+    console.info(`-> ${relDest.split(path.sep).join('/')} (${(size / 1024).toFixed(1)} KB)`)
+}
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true })
+fs.mkdirSync(OUT_DIR, { recursive: true })
+
+const buildDynamic = type === 'both' || type === 'dynamic'
+const buildStandalone = type === 'both' || type === 'standalone'
+
+if (buildDynamic && !publicPath) {
+    console.error('--public-path=<url> is required when building the dynamic bundle')
+    console.error('e.g. --public-path=https://bridge.playgama.com/v1/stable/')
+    process.exit(1)
+}
+
+// Dynamic first: it writes dist/platform-bridges/ which later standalone builds wipe.
+if (buildDynamic) {
+    console.info('\n=== Building dynamic bundle (main + platform chunks) ===')
+    const publicPathArg = publicPath ? ` --env publicPath=${publicPath}` : ''
+    run(`npx webpack --config-name dynamic --env noLint${publicPathArg}`)
+    ensureBuilt()
+    collect(BUILT_FILE, 'playgama-bridge.js')
+    if (!fs.existsSync(CHUNKS_DIR)) {
+        console.error(`Expected chunks dir not found: ${CHUNKS_DIR}`)
+        process.exit(1)
+    }
+    fs.cpSync(CHUNKS_DIR, path.join(OUT_DIR, 'platform-bridges'), { recursive: true })
+    const chunks = fs.readdirSync(CHUNKS_DIR).filter((n) => n.endsWith('.js'))
+    console.info(`-> platform-bridges/ (${chunks.length} chunk file(s))`)
+}
+
+if (buildStandalone) {
+    const platforms = singlePlatform ? [singlePlatform] : ALL_PLATFORM_IDS
+    console.info(`\n=== Building ${platforms.length} standalone bundle(s) ===`)
+    platforms.forEach((id) => {
+        console.info(`\n--- ${id} ---`)
+        run(`npx webpack --env platform=${id} --env noLint`)
+        ensureBuilt()
+        collect(BUILT_FILE, path.join('standalone', id, 'playgama-bridge.js'))
+    })
+}
+
+const produced = fs.readdirSync(OUT_DIR, { recursive: true })
+    .filter((name) => typeof name === 'string' && name.endsWith('.js'))
+    .sort()
+console.info(`\n=== Done. ${produced.length} file(s) in dist/publish/ ===`)
+produced.forEach((name) => console.info(`  ${name.split(path.sep).join('/')}`))

--- a/scripts/platforms.js
+++ b/scripts/platforms.js
@@ -16,4 +16,13 @@ while ((match = regex.exec(source)) !== null) {
     }
 }
 
-module.exports = { ALL_PLATFORM_IDS }
+// Platforms that must always be bundled together with the key platform.
+const PLATFORM_BUNDLE_EXTRAS = {
+    playgama: ['standalone'],
+}
+
+const expandPlatforms = (platforms) => Array.from(
+    new Set(platforms.flatMap((id) => [id, ...(PLATFORM_BUNDLE_EXTRAS[id] || [])])),
+)
+
+module.exports = { ALL_PLATFORM_IDS, expandPlatforms }

--- a/src/PlaygamaBridge.js
+++ b/src/PlaygamaBridge.js
@@ -133,6 +133,10 @@ class PlaygamaBridge {
         this.#engine = value
     }
 
+    set gameVersion(value) {
+        analyticsModule.gameVersion = value
+    }
+
     get PLATFORM_ID() {
         return PLATFORM_ID
     }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -532,7 +532,7 @@ export function createProgressLogo(showFullLoadingLogo, showLoadingText = false)
 
         #loading-overlay {
             font-size: 20px;
-            z-index: 1;
+            z-index: 9999999;
             display: flex;
             flex-direction: column;
             justify-content: center;

--- a/src/constants.js
+++ b/src/constants.js
@@ -166,6 +166,9 @@ export const PLATFORM_MESSAGE = {
     PLAYER_GOT_ACHIEVEMENT: 'player_got_achievement',
 }
 
+export const DEFAULT_PRICE_CURRENCY_CODE = 'USD'
+export const GAM_PER_USD = 10
+
 export const LEADERBOARD_TYPE = {
     NOT_AVAILABLE: 'not_available',
     IN_GAME: 'in_game',

--- a/src/modules/AdvertisementModule.js
+++ b/src/modules/AdvertisementModule.js
@@ -504,6 +504,16 @@ class AdvertisementModule extends ModuleBase {
         }
 
         this.#tryToShowAdvancedBanners(message)
+        this.#tryShowInterstitial(message)
+    }
+
+    #tryShowInterstitial(message) {
+        const events = this._platformBridge.options?.advertisement?.interstitial?.autoShow
+        if (!Array.isArray(events) || !events.includes(message)) {
+            return
+        }
+
+        this.showInterstitial(message)
     }
 
     #tryToShowAdvancedBanners(placement) {
@@ -694,7 +704,10 @@ class AdvertisementModule extends ModuleBase {
                 }
                 score += ADVANCED_BANNERS_SCORE.DEVICE_TYPE
             } else if (ORIENTATIONS_SET.has(segment)) {
-                if (segment !== orientation) {
+                // A square (1:1) viewport must not match any orientation, so a landscape-only
+                // banner is not shown at 1:1 scale. detectOrientation buckets square as landscape,
+                // hence the explicit square guard here.
+                if (segment !== orientation || window.innerWidth === window.innerHeight) {
                     return false
                 }
                 score += ADVANCED_BANNERS_SCORE.ORIENTATION

--- a/src/modules/AnalyticsModule.js
+++ b/src/modules/AnalyticsModule.js
@@ -25,6 +25,10 @@ const DISCORD_API_URL = '/playgama/api/events/v3/bridge/analytics'
 const FLUSH_INTERVAL = 30000
 
 class AnalyticsModule extends ModuleBase {
+    set gameVersion(value) {
+        this.#gameVersion = value
+    }
+
     #eventQueue = []
 
     #flushTimer = null
@@ -32,6 +36,8 @@ class AnalyticsModule extends ModuleBase {
     #gameId = null
 
     #playerGuestId = null
+
+    #gameVersion = null
 
     #sessionId = null
 
@@ -136,6 +142,7 @@ class AnalyticsModule extends ModuleBase {
             bridge_version: packageJson.version,
             platform_id: this._platformBridge.platformId,
             game_id: this.#gameId,
+            game_version: this.#gameVersion,
             session_id: this.#sessionId,
             player_id: this._platformBridge.playerId,
             player_guest_id: this.#playerGuestId,

--- a/src/modules/AnalyticsModule.js
+++ b/src/modules/AnalyticsModule.js
@@ -346,7 +346,9 @@ class AnalyticsModule extends ModuleBase {
                 }
             }
 
-            if (platformId === PLATFORM_ID.PLAYGAMA) {
+            // Standalone games are hosted outside playgama.com but still receive
+            // the game_id in the frame URL, so they resolve it the same way.
+            if (platformId === PLATFORM_ID.PLAYGAMA || platformId === PLATFORM_ID.STANDALONE) {
                 if (parsedUrl.searchParams.get('game_id')) {
                     return parsedUrl.searchParams.get('game_id')
                 }

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -15,6 +15,9 @@
  * along with Playgama Bridge. If not, see <https://www.gnu.org/licenses/>.
  */
 
+const SCREENSHOT_CAPTURE_FPS = 30
+const SCREENSHOT_FRAME_TIMEOUT_MS = 1000
+
 class RecorderModule {
     #captureGeneration = 0
 
@@ -174,12 +177,22 @@ class RecorderModule {
      * @param {number} [options.maxHeight] - Maximum screenshot height
      * @returns {{ success: boolean, reason: string | null, data: string | null }}
      */
-    takeScreenshot({
-        type = 'image/png',
-        quality = 0.92,
-        maxWidth,
-        maxHeight,
-    } = {}) {
+    takeScreenshot(options = {}) {
+        const sourceCanvas = this.#getCanvas()
+        if (!sourceCanvas) {
+            return { success: false, reason: 'Canvas not found', data: null }
+        }
+        return this.#serializeScreenshot(
+            sourceCanvas,
+            sourceCanvas.width,
+            sourceCanvas.height,
+            options,
+            sourceCanvas,
+        )
+    }
+
+    /** @returns {Promise<{ success: boolean, reason: string | null, data: string | null }>} */
+    async takeScreenshotFromSurface(options = {}) {
         const sourceCanvas = this.#getCanvas()
         if (!sourceCanvas) {
             return { success: false, reason: 'Canvas not found', data: null }
@@ -187,9 +200,78 @@ class RecorderModule {
         if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
             return { success: false, reason: 'Canvas has no drawable area', data: null }
         }
+        if (typeof sourceCanvas.captureStream !== 'function') {
+            return this.takeScreenshot(options)
+        }
+
+        let stream = null
+        let video = null
+        try {
+            stream = sourceCanvas.captureStream(SCREENSHOT_CAPTURE_FPS)
+            const track = stream.getVideoTracks()[0]
+            if (!track) {
+                return { success: false, reason: 'Canvas capture has no video track', data: null }
+            }
+
+            video = document.createElement('video')
+            video.srcObject = stream
+            video.muted = true
+            video.playsInline = true
+            await this.#waitForVideoFrame(video, track)
+            return this.#serializeScreenshot(
+                video,
+                video.videoWidth,
+                video.videoHeight,
+                options,
+            )
+        } catch (error) {
+            return {
+                success: false,
+                reason: error && typeof error === 'object' && 'message' in error
+                    ? String(error.message)
+                    : 'Screenshot capture failed',
+                data: null,
+            }
+        } finally {
+            video?.pause()
+            if (video) video.srcObject = null
+            stream?.getTracks().forEach((track) => track.stop())
+        }
+    }
+
+    /** Stops the capture, closes the peer connection and releases all tracks. */
+    stopCapture() {
+        this.#captureGeneration += 1
+        this.#clearCaptureResources()
+    }
+
+    #clearCaptureResources() {
+        this.#stream?.getTracks().forEach((t) => t.stop())
+        this.#pc?.close()
+        this.#pc = null
+        this.#pendingIceCandidates = []
+        this.#stream = null
+    }
+
+    #serializeScreenshot(source, sourceWidth, sourceHeight, {
+        type = 'image/png',
+        quality = 0.92,
+        maxWidth,
+        maxHeight,
+    } = {}, reusableCanvas = null) {
+        if (sourceWidth === 0 || sourceHeight === 0) {
+            return { success: false, reason: 'Screenshot source has no drawable area', data: null }
+        }
 
         try {
-            const canvas = this.#fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight)
+            const canvas = this.#fitScreenshotSource(
+                source,
+                sourceWidth,
+                sourceHeight,
+                maxWidth,
+                maxHeight,
+                reusableCanvas,
+            )
             if (!canvas) {
                 return { success: false, reason: 'Canvas context is not available', data: null }
             }
@@ -212,52 +294,28 @@ class RecorderModule {
         }
     }
 
-    /**
-     * Waits for the next paint before taking a screenshot.
-     * @param {Object} [options] - Screenshot options passed to takeScreenshot()
-     * @returns {Promise<{ success: boolean, reason: string | null, data: string | null }>}
-     */
-    async takeScreenshotAfterPaint(options = {}) {
-        await this.#waitForPaint()
-        return this.takeScreenshot(options)
-    }
-
-    /** Stops the capture, closes the peer connection and releases all tracks. */
-    stopCapture() {
-        this.#captureGeneration += 1
-        this.#clearCaptureResources()
-    }
-
-    #clearCaptureResources() {
-        this.#stream?.getTracks().forEach((t) => t.stop())
-        this.#pc?.close()
-        this.#pc = null
-        this.#pendingIceCandidates = []
-        this.#stream = null
-    }
-
-    #fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight) {
+    #fitScreenshotSource(source, sourceWidth, sourceHeight, maxWidth, maxHeight, reusableCanvas) {
         const widthLimit = typeof maxWidth === 'number'
             && Number.isFinite(maxWidth) && maxWidth > 0
             ? maxWidth
-            : sourceCanvas.width
+            : sourceWidth
         const heightLimit = typeof maxHeight === 'number'
             && Number.isFinite(maxHeight) && maxHeight > 0
             ? maxHeight
-            : sourceCanvas.height
+            : sourceHeight
         const scale = Math.min(
             1,
-            widthLimit / sourceCanvas.width,
-            heightLimit / sourceCanvas.height,
+            widthLimit / sourceWidth,
+            heightLimit / sourceHeight,
         )
-        if (scale === 1) return sourceCanvas
+        if (scale === 1 && reusableCanvas) return reusableCanvas
 
         const canvas = document.createElement('canvas')
-        canvas.width = Math.max(1, Math.round(sourceCanvas.width * scale))
-        canvas.height = Math.max(1, Math.round(sourceCanvas.height * scale))
+        canvas.width = Math.max(1, Math.round(sourceWidth * scale))
+        canvas.height = Math.max(1, Math.round(sourceHeight * scale))
         const context = canvas.getContext('2d')
         if (!context) return null
-        context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height)
+        context.drawImage(source, 0, 0, canvas.width, canvas.height)
         return canvas
     }
 
@@ -317,22 +375,47 @@ class RecorderModule {
         return typeof HTMLCanvasElement.prototype.captureStream === 'function'
     }
 
-    #waitForPaint() {
-        if (typeof requestAnimationFrame !== 'function') return Promise.resolve()
-
-        return new Promise((resolve) => {
-            let completed = false
-            let frameId = 0
-            let timeoutId
-            const finish = () => {
-                if (completed) return
-                completed = true
-                clearTimeout(timeoutId)
-                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId)
-                resolve()
+    #waitForVideoFrame(video, track) {
+        return new Promise((resolve, reject) => {
+            const cleanups = []
+            let frameCallbackId = null
+            let settled = false
+            const settle = (complete) => {
+                if (settled) return
+                settled = true
+                cleanups.forEach((cleanup) => cleanup())
+                complete()
             }
-            timeoutId = setTimeout(finish, 100)
-            frameId = requestAnimationFrame(finish)
+            const onEnded = () => settle(
+                () => reject(new Error('Canvas capture ended before its first frame')),
+            )
+            const onLoadedData = () => settle(resolve)
+            const timeoutId = setTimeout(() => settle(
+                () => reject(new Error('Canvas capture produced no video frames')),
+            ), SCREENSHOT_FRAME_TIMEOUT_MS)
+            cleanups.push(() => clearTimeout(timeoutId))
+            track.addEventListener('ended', onEnded, { once: true })
+            cleanups.push(() => track.removeEventListener('ended', onEnded))
+
+            if (typeof video.requestVideoFrameCallback === 'function') {
+                frameCallbackId = video.requestVideoFrameCallback(() => settle(resolve))
+                cleanups.push(() => {
+                    if (frameCallbackId !== null
+                        && typeof video.cancelVideoFrameCallback === 'function') {
+                        video.cancelVideoFrameCallback(frameCallbackId)
+                    }
+                })
+            } else {
+                video.addEventListener('loadeddata', onLoadedData, { once: true })
+                cleanups.push(() => video.removeEventListener('loadeddata', onLoadedData))
+            }
+
+            Promise.resolve(video.play()).then(() => {
+                if (typeof video.requestVideoFrameCallback !== 'function'
+                    && video.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) {
+                    settle(resolve)
+                }
+            }).catch((error) => settle(() => reject(error)))
         })
     }
 }

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -170,15 +170,56 @@ class RecorderModule {
      * @param {Object} [options]
      * @param {string} [options.type='image/png'] - Image MIME type
      * @param {number} [options.quality=0.92] - Image quality (0–1)
+     * @param {number} [options.maxWidth] - Maximum screenshot width
+     * @param {number} [options.maxHeight] - Maximum screenshot height
      * @returns {{ success: boolean, reason: string | null, data: string | null }}
      */
-    takeScreenshot({ type = 'image/png', quality = 0.92 } = {}) {
-        const canvas = this.#getCanvas()
-        if (!canvas) {
+    takeScreenshot({
+        type = 'image/png',
+        quality = 0.92,
+        maxWidth,
+        maxHeight,
+    } = {}) {
+        const sourceCanvas = this.#getCanvas()
+        if (!sourceCanvas) {
             return { success: false, reason: 'Canvas not found', data: null }
         }
-        const data = canvas.toDataURL(type, quality)
-        return { success: true, reason: null, data }
+        if (sourceCanvas.width === 0 || sourceCanvas.height === 0) {
+            return { success: false, reason: 'Canvas has no drawable area', data: null }
+        }
+
+        try {
+            const canvas = this.#fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight)
+            if (!canvas) {
+                return { success: false, reason: 'Canvas context is not available', data: null }
+            }
+            const normalizedQuality = Number.isFinite(quality)
+                ? Math.min(1, Math.max(0, quality))
+                : 0.92
+            const data = canvas.toDataURL(type, normalizedQuality)
+            if (data === 'data:,') {
+                return { success: false, reason: 'Canvas produced an empty screenshot', data: null }
+            }
+            return { success: true, reason: null, data }
+        } catch (error) {
+            return {
+                success: false,
+                reason: error && typeof error === 'object' && 'message' in error
+                    ? String(error.message)
+                    : 'Screenshot capture failed',
+                data: null,
+            }
+        }
+    }
+
+    /**
+     * Waits for the next paint before taking a screenshot.
+     * @param {Object} [options] - Screenshot options passed to takeScreenshot()
+     * @returns {Promise<{ success: boolean, reason: string | null, data: string | null }>}
+     */
+    async takeScreenshotAfterPaint(options = {}) {
+        await this.#waitForPaint()
+        return this.takeScreenshot(options)
     }
 
     /** Stops the capture, closes the peer connection and releases all tracks. */
@@ -193,6 +234,31 @@ class RecorderModule {
         this.#pc = null
         this.#pendingIceCandidates = []
         this.#stream = null
+    }
+
+    #fitScreenshotCanvas(sourceCanvas, maxWidth, maxHeight) {
+        const widthLimit = typeof maxWidth === 'number'
+            && Number.isFinite(maxWidth) && maxWidth > 0
+            ? maxWidth
+            : sourceCanvas.width
+        const heightLimit = typeof maxHeight === 'number'
+            && Number.isFinite(maxHeight) && maxHeight > 0
+            ? maxHeight
+            : sourceCanvas.height
+        const scale = Math.min(
+            1,
+            widthLimit / sourceCanvas.width,
+            heightLimit / sourceCanvas.height,
+        )
+        if (scale === 1) return sourceCanvas
+
+        const canvas = document.createElement('canvas')
+        canvas.width = Math.max(1, Math.round(sourceCanvas.width * scale))
+        canvas.height = Math.max(1, Math.round(sourceCanvas.height * scale))
+        const context = canvas.getContext('2d')
+        if (!context) return null
+        context.drawImage(sourceCanvas, 0, 0, canvas.width, canvas.height)
+        return canvas
     }
 
     #applyEncodingParams(peerConnection, {
@@ -249,6 +315,25 @@ class RecorderModule {
 
     #isCaptureStreamSupported() {
         return typeof HTMLCanvasElement.prototype.captureStream === 'function'
+    }
+
+    #waitForPaint() {
+        if (typeof requestAnimationFrame !== 'function') return Promise.resolve()
+
+        return new Promise((resolve) => {
+            let completed = false
+            let frameId = 0
+            let timeoutId
+            const finish = () => {
+                if (completed) return
+                completed = true
+                clearTimeout(timeoutId)
+                if (typeof cancelAnimationFrame === 'function') cancelAnimationFrame(frameId)
+                resolve()
+            }
+            timeoutId = setTimeout(finish, 100)
+            frameId = requestAnimationFrame(finish)
+        })
     }
 }
 

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -20,6 +20,8 @@ class RecorderModule {
 
     #pc = null
 
+    #pendingIceCandidates = []
+
     #stream = null
 
     #onOffer = null
@@ -132,11 +134,19 @@ class RecorderModule {
      * @param {string} params.sdp - Remote SDP answer string
      */
     async handleAnswer({ sdp }) {
-        if (this.#pc) {
-            await this.#pc.setRemoteDescription(
-                new RTCSessionDescription({ type: 'answer', sdp }),
-            )
-        }
+        const peerConnection = this.#pc
+        if (!peerConnection) return
+
+        await peerConnection.setRemoteDescription(
+            new RTCSessionDescription({ type: 'answer', sdp }),
+        )
+        if (peerConnection !== this.#pc) return
+
+        const pendingCandidates = this.#pendingIceCandidates
+        this.#pendingIceCandidates = []
+        await Promise.all(pendingCandidates.map((candidate) => (
+            peerConnection.addIceCandidate(new RTCIceCandidate(candidate))
+        )))
     }
 
     /**
@@ -144,9 +154,15 @@ class RecorderModule {
      * @param {RTCIceCandidateInit | null} candidate
      */
     async handleIce(candidate) {
-        if (this.#pc && candidate) {
-            await this.#pc.addIceCandidate(new RTCIceCandidate(candidate))
+        const peerConnection = this.#pc
+        if (!peerConnection || !candidate) return
+
+        if (!peerConnection.remoteDescription) {
+            this.#pendingIceCandidates.push(candidate)
+            return
         }
+
+        await peerConnection.addIceCandidate(new RTCIceCandidate(candidate))
     }
 
     /**
@@ -175,6 +191,7 @@ class RecorderModule {
         this.#stream?.getTracks().forEach((t) => t.stop())
         this.#pc?.close()
         this.#pc = null
+        this.#pendingIceCandidates = []
         this.#stream = null
     }
 

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -16,6 +16,8 @@
  */
 
 class RecorderModule {
+    #captureGeneration = 0
+
     #pc = null
 
     #stream = null
@@ -79,27 +81,46 @@ class RecorderModule {
 
         const canvas = this.#getCanvas()
 
-        this.#stream = canvas.captureStream(options.fps || 30)
+        this.#captureGeneration += 1
+        const generation = this.#captureGeneration
+        this.#clearCaptureResources()
+        const stream = canvas.captureStream(options.fps || 30)
+        this.#stream = stream
+        let peerConnection
+        try {
+            peerConnection = new RTCPeerConnection()
+        } catch (error) {
+            this.#clearCaptureResources()
+            throw error
+        }
+        this.#pc = peerConnection
 
         if (options.contentHint) {
-            const track = this.#stream.getVideoTracks()[0]
+            const track = stream.getVideoTracks()[0]
             if (track) track.contentHint = options.contentHint
         }
 
-        this.#pc = new RTCPeerConnection()
+        stream.getTracks().forEach((track) => peerConnection.addTrack(track, stream))
 
-        this.#stream.getTracks().forEach((t) => this.#pc.addTrack(t, this.#stream))
-
-        this.#pc.onicecandidate = (e) => {
-            if (e.candidate) {
+        peerConnection.onicecandidate = (e) => {
+            if (e.candidate && this.#isCurrentCapture(generation, peerConnection)) {
                 this.#onIceCandidate?.(e.candidate.toJSON())
             }
         }
 
-        const offer = await this.#pc.createOffer()
-        await this.#pc.setLocalDescription(offer)
+        let offer
+        try {
+            offer = await peerConnection.createOffer()
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+            await peerConnection.setLocalDescription(offer)
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+        } catch (error) {
+            if (!this.#isCurrentCapture(generation, peerConnection)) return
+            this.#clearCaptureResources()
+            throw error
+        }
 
-        this.#applyEncodingParams(options)
+        this.#applyEncodingParams(peerConnection, options)
 
         this.#onOffer?.(offer.sdp)
         this.#onStarted?.()
@@ -146,13 +167,18 @@ class RecorderModule {
 
     /** Stops the capture, closes the peer connection and releases all tracks. */
     stopCapture() {
+        this.#captureGeneration += 1
+        this.#clearCaptureResources()
+    }
+
+    #clearCaptureResources() {
         this.#stream?.getTracks().forEach((t) => t.stop())
         this.#pc?.close()
         this.#pc = null
         this.#stream = null
     }
 
-    #applyEncodingParams({
+    #applyEncodingParams(peerConnection, {
         maxBitrate,
         minBitrate,
         maxFramerate,
@@ -161,7 +187,7 @@ class RecorderModule {
         networkPriority,
         scalabilityMode,
     }) {
-        this.#pc.getSenders().forEach((sender) => {
+        peerConnection.getSenders().forEach((sender) => {
             if (sender.track?.kind !== 'video') return
             const params = sender.getParameters()
             if (!params.encodings?.length) {
@@ -190,6 +216,10 @@ class RecorderModule {
             }
             sender.setParameters(params)
         })
+    }
+
+    #isCurrentCapture(generation, peerConnection) {
+        return generation === this.#captureGeneration && peerConnection === this.#pc
     }
 
     #getCanvas() {

--- a/src/modules/RecorderModule.js
+++ b/src/modules/RecorderModule.js
@@ -68,6 +68,7 @@ class RecorderModule {
      * Starts canvas capture and creates a WebRTC offer.
      * @param {Object} [options]
      * @param {number} [options.fps=30] - Capture frame rate passed to captureStream()
+     * @param {RTCIceServer[]} [options.iceServers] - ICE servers used by the capture peer connection
      * @param {number} [options.maxBitrate] - Maximum bitrate in bits/s
      * @param {number} [options.minBitrate] - Minimum bitrate in bits/s
      * @param {number} [options.maxFramerate] - Maximum framerate at encoding level
@@ -93,7 +94,9 @@ class RecorderModule {
         this.#stream = stream
         let peerConnection
         try {
-            peerConnection = new RTCPeerConnection()
+            peerConnection = options.iceServers?.length
+                ? new RTCPeerConnection({ iceServers: options.iceServers })
+                : new RTCPeerConnection()
         } catch (error) {
             this.#clearCaptureResources()
             throw error

--- a/src/platform-bridges/GameSnacksPlatformBridge.js
+++ b/src/platform-bridges/GameSnacksPlatformBridge.js
@@ -82,7 +82,7 @@ class GameSnacksPlatformBridge extends PlatformBridgeBase {
                 })
 
                 this._platformSdk.game.firstFrameReady()
-                this._setAudioState(this._platformSdk.audio.isEnabled)
+                this._setAudioState(this._platformSdk.audio.isEnabled())
 
                 this._isInitialized = true
                 this._resolvePromiseDecorator(ACTION_NAME.INITIALIZE)

--- a/src/platform-bridges/MsnPlatformBridge.js
+++ b/src/platform-bridges/MsnPlatformBridge.js
@@ -100,6 +100,10 @@ class MsnPlatformBridge extends PlatformBridgeBase {
         return true
     }
 
+    get isAddToHomeScreenSupported() {
+        return typeof this._platformSdk?.promptInstallAsync === 'function'
+    }
+
     // leaderboards
     get leaderboardsType() {
         return LEADERBOARD_TYPE.NATIVE
@@ -293,6 +297,27 @@ class MsnPlatformBridge extends PlatformBridgeBase {
                 .then(resolve)
                 .catch(reject)
         })
+    }
+
+    addToHomeScreen() {
+        let promiseDecorator = this._getPromiseDecorator(ACTION_NAME.ADD_TO_HOME_SCREEN)
+        if (!promiseDecorator) {
+            promiseDecorator = this._createPromiseDecorator(ACTION_NAME.ADD_TO_HOME_SCREEN)
+            this._platformSdk.promptInstallAsync()
+                .then((outcome) => {
+                    if (outcome === 'accepted') {
+                        this._resolvePromiseDecorator(ACTION_NAME.ADD_TO_HOME_SCREEN)
+                        return
+                    }
+
+                    this._rejectPromiseDecorator(ACTION_NAME.ADD_TO_HOME_SCREEN)
+                })
+                .catch((error) => {
+                    this._rejectPromiseDecorator(ACTION_NAME.ADD_TO_HOME_SCREEN, error)
+                })
+        }
+
+        return promiseDecorator.promise
     }
 
     // leaderboards
@@ -725,7 +750,7 @@ class MsnPlatformBridge extends PlatformBridgeBase {
     #updatePlayerInfo(data) {
         if (data) {
             this._isPlayerAuthorized = true
-            this._playerId = data.playerId
+            this._playerId = data.playerId ?? data.publisherPlayerId
             this._playerName = data.playerDisplayName
             this._playerExtra = data
             this.#isPaymentsSupported = data.userAccountType.toLowerCase() === 'personal'

--- a/src/platform-bridges/PlaygamaPlatformBridge.js
+++ b/src/platform-bridges/PlaygamaPlatformBridge.js
@@ -494,7 +494,7 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
     }
 
     #getPlayer() {
-        if (!this.#isPlayerAuthorizationSupported) {
+        if (typeof this._platformSdk.userService?.getUser !== 'function') {
             this._playerApplyGuestData()
             return Promise.resolve()
         }
@@ -502,9 +502,14 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         return new Promise((resolve) => {
             this._platformSdk.userService.getUser()
                 .then((player) => {
+                    // The SDK id is used even for unauthorized players;
+                    // without it the locally generated guest id stays in place.
+                    if (player.id) {
+                        this._playerId = player.id
+                    }
+
                     if (player.isAuthorized) {
                         this._isPlayerAuthorized = true
-                        this._playerId = player.id
                         this._playerName = player.name
                         this._playerPhotos = player.photos
                         this._playerExtra = player

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -1221,11 +1221,13 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 recorderModule.handleIce(data.options)
                 break
             case RECORDER_ACTION.TAKE_SCREENSHOT: {
-                const result = recorderModule.takeScreenshot(data.options || {})
-                this.#sendMessage({
-                    type: MODULE_NAME.RECORDER,
-                    action: RECORDER_ACTION.SCREENSHOT_RESULT,
-                    payload: result,
+                recorderModule.takeScreenshotAfterPaint(data.options || {}).then((result) => {
+                    this.#sendMessage({
+                        type: MODULE_NAME.RECORDER,
+                        action: RECORDER_ACTION.SCREENSHOT_RESULT,
+                        id: data.id,
+                        payload: result,
+                    })
                 })
                 break
             }

--- a/src/platform-bridges/QaToolPlatformBridge.js
+++ b/src/platform-bridges/QaToolPlatformBridge.js
@@ -1221,7 +1221,7 @@ class QaToolPlatformBridge extends PlatformBridgeBase {
                 recorderModule.handleIce(data.options)
                 break
             case RECORDER_ACTION.TAKE_SCREENSHOT: {
-                recorderModule.takeScreenshotAfterPaint(data.options || {}).then((result) => {
+                recorderModule.takeScreenshotFromSurface(data.options || {}).then((result) => {
                     this.#sendMessage({
                         type: MODULE_NAME.RECORDER,
                         action: RECORDER_ACTION.SCREENSHOT_RESULT,

--- a/src/platform-bridges/StandalonePlatformBridge.js
+++ b/src/platform-bridges/StandalonePlatformBridge.js
@@ -35,7 +35,7 @@ class StandalonePlatformBridge extends PlaygamaPlatformBridge {
         return true
     }
 
-    _isAdvancedBannersSupported = false
+    _isAdvancedBannersSupported = true
 }
 
 export default StandalonePlatformBridge

--- a/src/platform-bridges/StandalonePlatformBridge.js
+++ b/src/platform-bridges/StandalonePlatformBridge.js
@@ -16,7 +16,7 @@
  */
 
 import PlaygamaPlatformBridge from './PlaygamaPlatformBridge'
-import { PLATFORM_ID } from '../constants'
+import { DEFAULT_PRICE_CURRENCY_CODE, GAM_PER_USD, PLATFORM_ID } from '../constants'
 
 class StandalonePlatformBridge extends PlaygamaPlatformBridge {
     get platformId() {
@@ -36,6 +36,74 @@ class StandalonePlatformBridge extends PlaygamaPlatformBridge {
     }
 
     _isAdvancedBannersSupported = true
+
+    // payments
+    paymentsGetCatalog() {
+        const products = this._paymentsGetProductsPlatformData()
+        if (!products) {
+            return Promise.reject()
+        }
+
+        const updatedProducts = products.map((product) => {
+            const { price, currency } = this.#resolveProductPrice(product)
+            return {
+                id: product.id,
+                price: price !== null ? `${price} ${currency}` : null,
+                priceCurrencyCode: price !== null ? currency : null,
+                priceValue: price,
+            }
+        })
+
+        return Promise.resolve(updatedProducts)
+    }
+
+    #resolveProductPrice(product) {
+        const price = this.#parsePrice(product.amount)
+        if (price !== null) {
+            const currency = typeof product.currency === 'string' && product.currency !== ''
+                ? product.currency
+                : DEFAULT_PRICE_CURRENCY_CODE
+            return { price, currency }
+        }
+
+        const playgamaProduct = this.#getPlaygamaProductPlatformData(product.id)
+
+        const playgamaAmount = this.#parsePrice(playgamaProduct?.amount)
+        if (playgamaAmount !== null) {
+            return { price: playgamaAmount / GAM_PER_USD, currency: DEFAULT_PRICE_CURRENCY_CODE }
+        }
+
+        return { price: null, currency: DEFAULT_PRICE_CURRENCY_CODE }
+    }
+
+    #getPlaygamaProductPlatformData(id) {
+        const products = this._options.payments
+        if (!products) {
+            return null
+        }
+
+        const product = products.find((p) => p.id === id)
+        if (!product) {
+            return null
+        }
+
+        return { ...product[PLATFORM_ID.PLAYGAMA], id: product.id }
+    }
+
+    #parsePrice(value) {
+        if (typeof value === 'number' && Number.isFinite(value)) {
+            return value
+        }
+
+        if (typeof value === 'string' && value !== '') {
+            const parsed = Number(value)
+            if (Number.isFinite(parsed)) {
+                return parsed
+            }
+        }
+
+        return null
+    }
 }
 
 export default StandalonePlatformBridge

--- a/src/platform-bridges/YoutubePlatformBridge.js
+++ b/src/platform-bridges/YoutubePlatformBridge.js
@@ -342,23 +342,7 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
     }
 
     #syncAudioState() {
-        if (typeof this._platformSdk?.system?.isAudioEnabled !== 'function') {
-            return
-        }
-
-        try {
-            Promise.resolve(this._platformSdk.system.isAudioEnabled())
-                .then((isEnabled) => {
-                    if (typeof isEnabled === 'boolean') {
-                        this._setAudioState(isEnabled)
-                    }
-                })
-                .catch(() => {
-                    // keep the last known state
-                })
-        } catch (e) {
-            // keep the last known state
-        }
+        this._setAudioState(this._platformSdk.system.isAudioEnabled())
     }
 
     #tryShowCrossPromo() {

--- a/src/platform-bridges/YoutubePlatformBridge.js
+++ b/src/platform-bridges/YoutubePlatformBridge.js
@@ -62,6 +62,10 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
         return false
     }
 
+    get isClipboardSupported() {
+        return false
+    }
+
     // leaderboards
     get leaderboardsType() {
         return LEADERBOARD_TYPE.NATIVE
@@ -70,6 +74,8 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
     #platformLanguage
 
     #subscribeNotification = null
+
+    #videoPreview = null
 
     initialize() {
         if (this._isInitialized) {
@@ -81,6 +87,7 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
 
             if (this.deviceType === DEVICE_TYPE.DESKTOP) {
                 this.#subscribeNotification = this.#createSubscribeNotification()
+                this.#videoPreview = this.#createVideoPreview()
             }
 
             waitFor('ytgame').then(() => {
@@ -279,6 +286,10 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
                 if (this.#subscribeNotification) {
                     this.#subscribeNotification.remove()
                     this.#subscribeNotification = null
+                }
+                if (this.#videoPreview) {
+                    this.#videoPreview.remove()
+                    this.#videoPreview = null
                 }
                 return Promise.resolve()
             }
@@ -502,6 +513,93 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
                 </svg>
             </div>
         `
+
+        document.body.appendChild(container)
+        return container
+    }
+
+    #createVideoPreview() {
+        const previews = (this._options.videoPreviews ?? [])
+            .filter((preview) => Boolean(preview?.image && preview?.videoId))
+        if (previews.length === 0) {
+            return null
+        }
+
+        const { image, videoId } = previews[Math.floor(Math.random() * previews.length)]
+
+        if (!document.getElementById('bridge-youtube-video-preview-styles')) {
+            const style = document.createElement('style')
+            style.id = 'bridge-youtube-video-preview-styles'
+            style.textContent = `
+                #bridge-youtube-video-preview {
+                    position: fixed;
+                    bottom: -24px;
+                    right: 24px;
+                    width: min(256px, 40vw);
+                    border-radius: 16px;
+                    overflow: hidden;
+                    background-color: #000;
+                    box-shadow: 0 8px 24px 0 rgba(0, 0, 0, 0.4);
+                    cursor: pointer;
+                    opacity: 0;
+                    z-index: 9999999;
+                    animation: bridge-yt-preview-rise 285ms ease-out 590ms forwards;
+                }
+
+                #bridge-youtube-video-preview .bridge-yt-preview-image {
+                    display: block;
+                    width: 100%;
+                    aspect-ratio: 16 / 9;
+                    object-fit: cover;
+                    user-select: none;
+                    -webkit-user-drag: none;
+                }
+
+                #bridge-youtube-video-preview .bridge-yt-preview-play {
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    width: 48px;
+                    height: 34px;
+                    transform: translate(-50%, -50%);
+                    pointer-events: none;
+                }
+
+                @keyframes bridge-yt-preview-rise {
+                    0%   { bottom: -24px;  opacity: 0; }
+                    40%  { bottom: 25.6px; opacity: 1; }
+                    48%  { bottom: 33.6px; }
+                    60%  { bottom: 32px; }
+                    70%  { bottom: 30.4px; }
+                    79%  { bottom: 28.8px; }
+                    88%  { bottom: 27.2px; }
+                    95%  { bottom: 25.6px; }
+                    100% { bottom: 24px;   opacity: 1; }
+                }
+            `
+            document.head.appendChild(style)
+        }
+
+        const container = document.createElement('div')
+        container.id = 'bridge-youtube-video-preview'
+
+        const img = document.createElement('img')
+        img.className = 'bridge-yt-preview-image'
+        img.src = image
+        img.alt = ''
+        img.draggable = false
+        container.appendChild(img)
+
+        container.insertAdjacentHTML('beforeend', `
+            <svg class="bridge-yt-preview-play" viewBox="0 0 68 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path d="M66.52 7.74C65.74 4.81 64.03 2.33 61.1 1.55C55.79 0.13 34 0 34 0C34 0 12.21 0.13 6.9 1.55C3.97 2.33 2.27 4.81 1.48 7.74C0.06 13.05 0 24 0 24C0 24 0.06 34.95 1.48 40.26C2.27 43.19 3.97 45.67 6.9 46.45C12.21 47.87 34 48 34 48C34 48 55.79 47.87 61.1 46.45C64.03 45.67 65.74 43.19 66.52 40.26C67.94 34.95 68 24 68 24C68 24 67.94 13.05 66.52 7.74Z" fill="#FF0033"/>
+                <path d="M45 24L27 14V34L45 24Z" fill="white"/>
+            </svg>
+        `)
+
+        container.addEventListener('click', () => {
+            window.ytgame?.engagement.openYTContent({ id: videoId }).catch(() => {})
+        })
 
         document.body.appendChild(container)
         return container

--- a/src/platform-bridges/YoutubePlatformBridge.js
+++ b/src/platform-bridges/YoutubePlatformBridge.js
@@ -27,6 +27,7 @@ import {
     REWARDED_STATE,
     INTERSTITIAL_STATE,
     DEVICE_TYPE,
+    VISIBILITY_STATE,
 } from '../constants'
 
 class YoutubePlatformBridge extends PlatformBridgeBase {
@@ -102,6 +103,21 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
                     this._setAudioState(isEnabled)
                 })
 
+                this.#syncAudioState()
+
+                // onAudioEnabledChange is not delivered on some Android devices when the toggle
+                // happens while the game iframe is paused or frozen, so re-read the actual state
+                // every time the game comes back to the foreground
+                document.addEventListener('visibilitychange', () => {
+                    if (document.visibilityState === VISIBILITY_STATE.VISIBLE) {
+                        this.#syncAudioState()
+                    }
+                })
+
+                window.addEventListener('pageshow', () => {
+                    this.#syncAudioState()
+                })
+
                 this._platformSdk.system.onPause(() => {
                     this._setPauseState(true)
                     this.#tryShowCrossPromo()
@@ -110,6 +126,7 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
                 this._platformSdk.system.onResume(() => {
                     this._setPauseState(false)
                     crossPromoModule.hide()
+                    this.#syncAudioState()
                 })
 
                 Promise.all([getLanguagePromise, getDataPromise])
@@ -322,6 +339,26 @@ class YoutubePlatformBridge extends PlatformBridgeBase {
         }
 
         return promiseDecorator.promise
+    }
+
+    #syncAudioState() {
+        if (typeof this._platformSdk?.system?.isAudioEnabled !== 'function') {
+            return
+        }
+
+        try {
+            Promise.resolve(this._platformSdk.system.isAudioEnabled())
+                .then((isEnabled) => {
+                    if (typeof isEnabled === 'boolean') {
+                        this._setAudioState(isEnabled)
+                    }
+                })
+                .catch(() => {
+                    // keep the last known state
+                })
+        } catch (e) {
+            // keep the last known state
+        }
     }
 
     #tryShowCrossPromo() {

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -26,12 +26,16 @@ function createMockRTCPeerConnection() {
         addTrack: vi.fn(),
         createOffer: vi.fn().mockResolvedValue({ sdp: 'mock-offer-sdp', type: 'offer' }),
         setLocalDescription: vi.fn().mockResolvedValue(undefined),
-        setRemoteDescription: vi.fn().mockResolvedValue(undefined),
+        setRemoteDescription: vi.fn(),
+        remoteDescription: null as RTCSessionDescriptionInit | null,
         addIceCandidate: vi.fn().mockResolvedValue(undefined),
         getSenders: vi.fn().mockReturnValue([mockSender]),
         close: vi.fn(),
         onicecandidate: null as ((e: { candidate: unknown }) => void) | null,
     }
+    mockPc.setRemoteDescription.mockImplementation(async (description) => {
+        mockPc.remoteDescription = description
+    })
 
     global.RTCPeerConnection = vi.fn().mockImplementation(() => mockPc) as unknown as typeof RTCPeerConnection
     return mockPc
@@ -348,16 +352,61 @@ describe('RecorderModule', () => {
     })
 
     describe('handleIce', () => {
-        test('should add ice candidate after startCapture', async () => {
+        test('should add ice candidate after remote answer is set', async () => {
             canvas = createMockCanvas()
             const mockPc = createMockRTCPeerConnection()
 
             const candidate = { candidate: 'mock', sdpMid: '0', sdpMLineIndex: 0 }
             const module = createRecorderModule()
             await module.startCapture()
+            await module.handleAnswer({ sdp: 'mock-answer-sdp' })
             await module.handleIce(candidate)
 
             expect(mockPc.addIceCandidate).toHaveBeenCalled()
+        })
+
+        test('should queue ice candidate while remote answer is being set', async () => {
+            canvas = createMockCanvas()
+            const mockPc = createMockRTCPeerConnection()
+            let resolveRemoteDescription!: () => void
+            mockPc.setRemoteDescription.mockImplementation((description) => new Promise<void>((resolve) => {
+                resolveRemoteDescription = () => {
+                    mockPc.remoteDescription = description
+                    resolve()
+                }
+            }))
+
+            const candidate = { candidate: 'early', sdpMid: '0', sdpMLineIndex: 0 }
+            const module = createRecorderModule()
+            await module.startCapture()
+            const answerPromise = module.handleAnswer({ sdp: 'mock-answer-sdp' })
+            await vi.waitFor(() => expect(mockPc.setRemoteDescription).toHaveBeenCalled())
+
+            await module.handleIce(candidate)
+            expect(mockPc.addIceCandidate).not.toHaveBeenCalled()
+
+            resolveRemoteDescription()
+            await answerPromise
+            expect(mockPc.addIceCandidate).toHaveBeenCalledWith(candidate)
+        })
+
+        test('should discard queued ice candidates when capture stops', async () => {
+            canvas = createMockCanvas()
+            const firstPc = createMockRTCPeerConnection()
+            const secondPc = createMockRTCPeerConnection()
+            global.RTCPeerConnection = vi.fn()
+                .mockImplementationOnce(() => firstPc)
+                .mockImplementationOnce(() => secondPc) as unknown as typeof RTCPeerConnection
+
+            const module = createRecorderModule()
+            await module.startCapture()
+            await module.handleIce({ candidate: 'stale', sdpMid: '0', sdpMLineIndex: 0 })
+            module.stopCapture()
+            await module.startCapture()
+            await module.handleAnswer({ sdp: 'fresh-answer-sdp' })
+
+            expect(firstPc.addIceCandidate).not.toHaveBeenCalled()
+            expect(secondPc.addIceCandidate).not.toHaveBeenCalled()
         })
 
         test('should do nothing when peer connection does not exist', async () => {

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -21,6 +21,51 @@ function createMockCanvas(options: {
     return canvas
 }
 
+function mockCapturedScreenshotFrame(
+    sourceCanvas: HTMLCanvasElement,
+    data = 'data:image/jpeg;base64,capturedFrame',
+) {
+    const track = {
+        kind: 'video',
+        readyState: 'live',
+        stop: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    }
+    const stream = {
+        getVideoTracks: () => [track],
+        getTracks: () => [track],
+    }
+    sourceCanvas.captureStream = vi.fn().mockReturnValue(stream)
+
+    const video = document.createElement('video')
+    Object.defineProperties(video, {
+        videoWidth: { value: sourceCanvas.width },
+        videoHeight: { value: sourceCanvas.height },
+        requestVideoFrameCallback: {
+            value: vi.fn((callback: VideoFrameRequestCallback) => {
+                queueMicrotask(() => callback(0, {} as VideoFrameCallbackMetadata))
+                return 1
+            }),
+        },
+        cancelVideoFrameCallback: { value: vi.fn() },
+    })
+    vi.spyOn(video, 'play').mockResolvedValue(undefined)
+    vi.spyOn(video, 'pause').mockImplementation(() => {})
+
+    const outputCanvas = document.createElement('canvas')
+    const drawImage = vi.fn()
+    vi.spyOn(outputCanvas, 'getContext').mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D)
+    vi.spyOn(outputCanvas, 'toDataURL').mockReturnValue(data)
+    vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+        if (tagName === 'video') return video
+        if (tagName === 'canvas') return outputCanvas
+        throw new Error(`Unexpected element: ${tagName}`)
+    })
+
+    return { stream, track, video, outputCanvas, drawImage }
+}
+
 function createMockRTCPeerConnection() {
     const setParameters = vi.fn().mockResolvedValue(undefined)
     const mockSender = {
@@ -441,22 +486,50 @@ describe('RecorderModule', () => {
             expect(result).toEqual({ success: false, reason: 'Canvas not found', data: null })
         })
 
-        test('should wait for paint and return base64 data from canvas', async () => {
-            canvas = createMockCanvas({ toDataURL: 'data:image/png;base64,screenshotData' })
-            vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
-                callback(0)
-                return 1
-            })
-            vi.stubGlobal('cancelAnimationFrame', vi.fn())
+        test('should capture the painted surface without reading the source drawing buffer', async () => {
+            canvas = createMockCanvas()
+            const sourceToDataURL = canvas.toDataURL
+            const { track, video, outputCanvas, drawImage } = mockCapturedScreenshotFrame(canvas)
 
             const module = createRecorderModule()
-            const result = await module.takeScreenshotAfterPaint()
+            const result = await module.takeScreenshotFromSurface({
+                type: 'image/jpeg',
+                quality: 0.85,
+            })
 
+            expect(sourceToDataURL).not.toHaveBeenCalled()
+            expect(canvas.captureStream).toHaveBeenCalledWith(30)
+            expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 1280, 720)
+            expect(outputCanvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.85)
+            expect(track.stop).toHaveBeenCalledOnce()
             expect(result).toEqual({
                 success: true,
                 reason: null,
-                data: 'data:image/png;base64,screenshotData',
+                data: 'data:image/jpeg;base64,capturedFrame',
             })
+        })
+
+        test('should stop only the screenshot track while recording capture is active', async () => {
+            canvas = createMockCanvas()
+            const recordingTrack = { kind: 'video', stop: vi.fn() }
+            const recordingStream = {
+                getVideoTracks: () => [recordingTrack],
+                getTracks: () => [recordingTrack],
+            }
+            const { stream, track } = mockCapturedScreenshotFrame(canvas)
+            vi.mocked(canvas.captureStream)
+                .mockReset()
+                .mockReturnValueOnce(recordingStream as unknown as MediaStream)
+                .mockReturnValueOnce(stream as unknown as MediaStream)
+            const peerConnection = createMockRTCPeerConnection()
+            const module = createRecorderModule()
+
+            await module.startCapture()
+            await module.takeScreenshotFromSurface()
+
+            expect(recordingTrack.stop).not.toHaveBeenCalled()
+            expect(track.stop).toHaveBeenCalledOnce()
+            expect(peerConnection.close).not.toHaveBeenCalled()
         })
 
         test('should use default type and quality', () => {

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -152,6 +152,38 @@ describe('RecorderModule', () => {
             expect(canvas.captureStream).toHaveBeenCalledWith(30)
         })
 
+        test('should stop the stream when peer connection creation fails', async () => {
+            const stop = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop }],
+            })
+            global.RTCPeerConnection = vi.fn().mockImplementation(() => {
+                throw new Error('Peer connection creation failed')
+            }) as unknown as typeof RTCPeerConnection
+
+            const module = createRecorderModule()
+
+            await expect(module.startCapture()).rejects.toThrow('Peer connection creation failed')
+            expect(stop).toHaveBeenCalledOnce()
+        })
+
+        test('should release capture resources when offer creation fails', async () => {
+            const stop = vi.fn()
+            canvas = createMockCanvas()
+            canvas.captureStream = vi.fn().mockReturnValue({
+                getTracks: () => [{ stop }],
+            })
+            const mockPc = createMockRTCPeerConnection()
+            mockPc.createOffer = vi.fn().mockRejectedValue(new Error('Offer creation failed'))
+
+            const module = createRecorderModule()
+
+            await expect(module.startCapture()).rejects.toThrow('Offer creation failed')
+            expect(stop).toHaveBeenCalledOnce()
+            expect(mockPc.close).toHaveBeenCalledOnce()
+        })
+
         test('should apply maxBitrate to video sender', async () => {
             canvas = createMockCanvas()
             const mockPc = createMockRTCPeerConnection()
@@ -248,6 +280,50 @@ describe('RecorderModule', () => {
 
             const module = createRecorderModule()
             await expect(module.startCapture()).resolves.toBeUndefined()
+        })
+
+        test('should not emit an old offer after a newer capture starts', async () => {
+            canvas = createMockCanvas()
+            const firstPc = createMockRTCPeerConnection()
+            const secondPc = createMockRTCPeerConnection()
+            let resolveFirstOffer!: (offer: RTCSessionDescriptionInit) => void
+            firstPc.createOffer = vi.fn(() => new Promise((resolve) => {
+                resolveFirstOffer = resolve
+            }))
+            secondPc.createOffer = vi.fn().mockResolvedValue({
+                sdp: 'fresh-offer-sdp',
+                type: 'offer',
+            })
+            global.RTCPeerConnection = vi.fn()
+                .mockImplementationOnce(() => firstPc)
+                .mockImplementationOnce(() => secondPc) as unknown as typeof RTCPeerConnection
+            const onOffer = vi.fn()
+            const onIceCandidate = vi.fn()
+            const onStarted = vi.fn()
+            const module = createRecorderModule()
+            module.onOffer = onOffer
+            module.onIceCandidate = onIceCandidate
+            module.onStarted = onStarted
+
+            const firstStart = module.startCapture()
+            await vi.waitFor(() => expect(firstPc.createOffer).toHaveBeenCalled())
+            module.stopCapture()
+            await module.startCapture()
+            resolveFirstOffer({ sdp: 'stale-offer-sdp', type: 'offer' })
+            await firstStart
+            firstPc.onicecandidate?.({
+                candidate: { toJSON: () => ({ candidate: 'stale-candidate' }) },
+            })
+            secondPc.onicecandidate?.({
+                candidate: { toJSON: () => ({ candidate: 'fresh-candidate' }) },
+            })
+
+            expect(onOffer).toHaveBeenCalledOnce()
+            expect(onOffer).toHaveBeenCalledWith('fresh-offer-sdp')
+            expect(onIceCandidate).toHaveBeenCalledOnce()
+            expect(onIceCandidate).toHaveBeenCalledWith({ candidate: 'fresh-candidate' })
+            expect(onStarted).toHaveBeenCalledOnce()
+            expect(firstPc.setLocalDescription).not.toHaveBeenCalled()
         })
     })
 

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -5,8 +5,14 @@ function createRecorderModule() {
     return new RecorderModule()
 }
 
-function createMockCanvas(options: { toDataURL?: string } = {}) {
+function createMockCanvas(options: {
+    width?: number
+    height?: number
+    toDataURL?: string
+} = {}) {
     const canvas = document.createElement('canvas')
+    canvas.width = options.width ?? 1280
+    canvas.height = options.height ?? 720
     vi.spyOn(canvas, 'toDataURL').mockReturnValue(options.toDataURL || 'data:image/png;base64,mockData')
     canvas.captureStream = vi.fn().mockReturnValue({
         getTracks: () => [{ stop: vi.fn() }],
@@ -52,6 +58,7 @@ describe('RecorderModule', () => {
     })
 
     afterEach(() => {
+        vi.unstubAllGlobals()
         if (canvas) {
             canvas.remove()
             canvas = null
@@ -434,11 +441,16 @@ describe('RecorderModule', () => {
             expect(result).toEqual({ success: false, reason: 'Canvas not found', data: null })
         })
 
-        test('should return base64 data from canvas', () => {
+        test('should wait for paint and return base64 data from canvas', async () => {
             canvas = createMockCanvas({ toDataURL: 'data:image/png;base64,screenshotData' })
+            vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+                callback(0)
+                return 1
+            })
+            vi.stubGlobal('cancelAnimationFrame', vi.fn())
 
             const module = createRecorderModule()
-            const result = module.takeScreenshot()
+            const result = await module.takeScreenshotAfterPaint()
 
             expect(result).toEqual({
                 success: true,
@@ -463,6 +475,41 @@ describe('RecorderModule', () => {
             module.takeScreenshot({ type: 'image/jpeg', quality: 0.5 })
 
             expect(canvas.toDataURL).toHaveBeenCalledWith('image/jpeg', 0.5)
+        })
+
+        test('should return an error when canvas serialization fails', () => {
+            canvas = createMockCanvas()
+            vi.spyOn(canvas, 'toDataURL').mockImplementation(() => {
+                throw new DOMException('Canvas is tainted', 'SecurityError')
+            })
+
+            const module = createRecorderModule()
+
+            expect(module.takeScreenshot()).toEqual({
+                success: false,
+                reason: 'Canvas is tainted',
+                data: null,
+            })
+        })
+
+        test('should downscale oversized screenshots', () => {
+            canvas = createMockCanvas({ width: 3840, height: 2160 })
+            const resizedCanvas = document.createElement('canvas')
+            const drawImage = vi.fn()
+            vi.spyOn(document, 'createElement').mockImplementation((tagName: string) => {
+                if (tagName === 'canvas') return resizedCanvas
+                throw new Error(`Unexpected element: ${tagName}`)
+            })
+            vi.spyOn(resizedCanvas, 'getContext').mockReturnValue({ drawImage } as unknown as CanvasRenderingContext2D)
+            vi.spyOn(resizedCanvas, 'toDataURL').mockReturnValue('data:image/png;base64,resized')
+
+            const module = createRecorderModule()
+            const result = module.takeScreenshot({ maxWidth: 1920, maxHeight: 1080 })
+
+            expect(resizedCanvas.width).toBe(1920)
+            expect(resizedCanvas.height).toBe(1080)
+            expect(drawImage).toHaveBeenCalledWith(canvas, 0, 0, 1920, 1080)
+            expect(result.data).toBe('data:image/png;base64,resized')
         })
     })
 

--- a/tests/src/modules/recorderModule.spec.ts
+++ b/tests/src/modules/recorderModule.spec.ts
@@ -182,10 +182,26 @@ describe('RecorderModule', () => {
             module.onStarted = onStarted
             await module.startCapture()
 
+            expect(global.RTCPeerConnection).toHaveBeenCalledWith()
             expect(mockPc.createOffer).toHaveBeenCalled()
             expect(mockPc.setLocalDescription).toHaveBeenCalled()
             expect(onOffer).toHaveBeenCalledWith('mock-offer-sdp')
             expect(onStarted).toHaveBeenCalled()
+        })
+
+        test('should configure the peer connection with provided ICE servers', async () => {
+            canvas = createMockCanvas()
+            createMockRTCPeerConnection()
+            const iceServers: RTCIceServer[] = [{
+                urls: 'turn:turn.example.com',
+                username: 'user',
+                credential: 'credential',
+            }]
+
+            const module = createRecorderModule()
+            await module.startCapture({ iceServers })
+
+            expect(global.RTCPeerConnection).toHaveBeenCalledWith({ iceServers })
         })
 
         test('should use custom fps', async () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,7 +4,7 @@ const webpack = require('webpack')
 const ESLintPlugin = require('eslint-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const packageJson = require('./package.json')
-const { ALL_PLATFORM_IDS } = require('./scripts/platforms')
+const { ALL_PLATFORM_IDS, expandPlatforms } = require('./scripts/platforms')
 
 const platformDirName = 'platform-bridges'
 const CDN_BASE_URL = `https://bridge.playgama.com/v${packageJson.version.split('.')[0]}/stable/`
@@ -101,7 +101,7 @@ const createConfig = (targetPlatforms = [], { noLint = false } = {}) => ({
 
 module.exports = (env = {}, argv = {}) => {
     const targetPlatform = env.platform || ''
-    const targetPlatforms = targetPlatform ? targetPlatform.split(',') : []
+    const targetPlatforms = targetPlatform ? expandPlatforms(targetPlatform.split(',')) : []
     const noLint = Boolean(env.noLint)
     const isDevelopment = argv.mode === 'development'
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -131,7 +131,9 @@ module.exports = (env = {}, argv = {}) => {
         name: 'dynamic',
         output: {
             ...baseConfig.output,
-            publicPath: isDevelopment ? 'auto' : CDN_BASE_URL,
+            // env.publicPath: absolute URL the dynamic bundle uses to fetch its
+            // platform-bridges/ chunks, e.g. https://<domain>/v<major>/<channel>/
+            publicPath: isDevelopment ? 'auto' : (env.publicPath || CDN_BASE_URL),
         },
         plugins: [
             ...baseConfig.plugins,


### PR DESCRIPTION
Standalone games (TheLoop microsites) are launched with game_id in the frame URL, but the analytics module read that query param only when platformId === playgama. As a result, all standalone events are sent with an empty game_id.

For some of the games this is not critical, since they were built with a patched config that contained a publicKey.