### PR TITLE
Allow platform storage for anonymous Playgama players

### DIFF
--- a/src/platform-bridges/PlaygamaPlatformBridge.ts
+++ b/src/platform-bridges/PlaygamaPlatformBridge.ts
@@ -162,8 +162,6 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
 
     #isCloudSaveSupported = true
 
-    #isAnonymousCloudSaveAllowed = false
-
     #isPlayerAuthorizationSupported = true
 
     #isShareSupported = false
@@ -243,9 +241,6 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
                             if (sdk.platformService?.getAdditionalParams) {
                                 this._additionalData = sdk.platformService.getAdditionalParams() || {}
                             }
-
-                            this.#isAnonymousCloudSaveAllowed = this._additionalData
-                                ?.isAnonymousCloudSaveAllowed === true
 
                             return this.#getPlayer()
                         })
@@ -577,9 +572,9 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         this.#isAddToHomeScreenSupported = socialService?.getIsAddToHomeScreenSupported?.() ?? false
     }
 
-    // Anonymous players keep platform storage when the platform accepts their cloud save messages
+    // Playgama routes platform storage to the appropriate guest or authorized-player backend.
     #isCloudSaveAvailable(): boolean {
-        return this.#isCloudSaveSupported && (this._isPlayerAuthorized || this.#isAnonymousCloudSaveAllowed)
+        return this.#isCloudSaveSupported
     }
 
     #refreshPlatformStorageAvailability(): void {

--- a/src/platform-bridges/PlaygamaPlatformBridge.ts
+++ b/src/platform-bridges/PlaygamaPlatformBridge.ts
@@ -525,7 +525,6 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         const sdk = this._platformSdk as PlaygamaSdk
         if (typeof sdk.userService?.getUser !== 'function') {
             this._playerApplyGuestData()
-            this.#refreshPlatformStorageAvailability()
             return Promise.resolve()
         }
 
@@ -543,11 +542,13 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
                         this._playerName = player.name
                         this._playerPhotos = player.photos
                         this._playerExtra = player as unknown as Record<string, unknown>
+                        if (this.#isCloudSaveSupported) {
+                            this._setPlatformStorageAvailable(true)
+                        }
                     }
                 })
                 .catch(() => {})
                 .finally(() => {
-                    this.#refreshPlatformStorageAvailability()
                     resolve()
                 })
         })
@@ -562,6 +563,7 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         if (sdk.platformService?.getIsCloudSaveSupported) {
             this.#isCloudSaveSupported = sdk.platformService.getIsCloudSaveSupported()
         }
+        this._setPlatformStorageAvailable(this.#isCloudSaveSupported)
 
         if (sdk.platformService?.getIsPaymentsSupported) {
             this.#isPaymentsSupported = sdk.platformService.getIsPaymentsSupported()
@@ -572,17 +574,8 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         this.#isAddToHomeScreenSupported = socialService?.getIsAddToHomeScreenSupported?.() ?? false
     }
 
-    // Playgama routes platform storage to the appropriate guest or authorized-player backend.
-    #isCloudSaveAvailable(): boolean {
-        return this.#isCloudSaveSupported
-    }
-
-    #refreshPlatformStorageAvailability(): void {
-        this._setPlatformStorageAvailable(this.#isCloudSaveAvailable())
-    }
-
     #ensureStorageReady(): Promise<void> {
-        if (!this.#isCloudSaveAvailable()) {
+        if (!this.#isCloudSaveSupported) {
             return Promise.reject()
         }
         return Promise.resolve()

--- a/src/platform-bridges/PlaygamaPlatformBridge.ts
+++ b/src/platform-bridges/PlaygamaPlatformBridge.ts
@@ -162,6 +162,8 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
 
     #isCloudSaveSupported = true
 
+    #isAnonymousCloudSaveAllowed = false
+
     #isPlayerAuthorizationSupported = true
 
     #isShareSupported = false
@@ -241,6 +243,9 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
                             if (sdk.platformService?.getAdditionalParams) {
                                 this._additionalData = sdk.platformService.getAdditionalParams() || {}
                             }
+
+                            this.#isAnonymousCloudSaveAllowed = this._additionalData
+                                ?.isAnonymousCloudSaveAllowed === true
 
                             return this.#getPlayer()
                         })
@@ -525,6 +530,7 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         const sdk = this._platformSdk as PlaygamaSdk
         if (typeof sdk.userService?.getUser !== 'function') {
             this._playerApplyGuestData()
+            this.#refreshPlatformStorageAvailability()
             return Promise.resolve()
         }
 
@@ -542,13 +548,11 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
                         this._playerName = player.name
                         this._playerPhotos = player.photos
                         this._playerExtra = player as unknown as Record<string, unknown>
-                        if (this.#isCloudSaveSupported) {
-                            this._setPlatformStorageAvailable(true)
-                        }
                     }
                 })
                 .catch(() => {})
                 .finally(() => {
+                    this.#refreshPlatformStorageAvailability()
                     resolve()
                 })
         })
@@ -573,8 +577,17 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
         this.#isAddToHomeScreenSupported = socialService?.getIsAddToHomeScreenSupported?.() ?? false
     }
 
+    // Anonymous players keep platform storage when the platform accepts their cloud save messages
+    #isCloudSaveAvailable(): boolean {
+        return this.#isCloudSaveSupported && (this._isPlayerAuthorized || this.#isAnonymousCloudSaveAllowed)
+    }
+
+    #refreshPlatformStorageAvailability(): void {
+        this._setPlatformStorageAvailable(this.#isCloudSaveAvailable())
+    }
+
     #ensureStorageReady(): Promise<void> {
-        if (!this.#isCloudSaveSupported || !this._isPlayerAuthorized) {
+        if (!this.#isCloudSaveAvailable()) {
             return Promise.reject()
         }
         return Promise.resolve()


### PR DESCRIPTION
Playgama now reports isAnonymousCloudSaveAllowed through its additional params, meaning the platform accepts cloud save messages from unauthorized players and persists them locally instead of in the cloud.

Treat platform storage as available whenever cloud save is supported and either the player is authorized or the platform allows anonymous saves, so guests keep a single storage API instead of silently falling back.

This is the v2 counterpart to #249.