### PR TITLE
DEV-6218: Align Playgama SDK adapter types

### DIFF
--- a/src/platform-bridges/PlaygamaPlatformBridge.ts
+++ b/src/platform-bridges/PlaygamaPlatformBridge.ts
@@ -30,7 +30,7 @@ import {
 } from '../modules/advertisement/constants'
 import type { WriteBatch } from '../modules/storage/types'
 
-type AdType = 'interstitial' | 'rewarded'
+type AdType = 'interstitial' | 'interstitial_preroll' | 'rewarded'
 type AdState = 'open' | 'empty' | 'rewarded' | 'close' | 'error' | string
 
 interface PlaygamaPlayer {
@@ -41,15 +41,34 @@ interface PlaygamaPlayer {
     [key: string]: unknown
 }
 
-interface PlaygamaPurchase {
-    status: string
+interface PlaygamaPaidPurchase extends AnyRecord {
+    status: 'PAID'
+    orderId: string
+    amount: number
+    externalId?: string
+}
+
+interface PlaygamaFailedPurchase extends AnyRecord {
+    status: 'FAILED'
+    error: unknown
+}
+
+type PlaygamaPurchase = PlaygamaPaidPurchase | PlaygamaFailedPurchase
+
+// Playgama v1 returns orderId/externalId. Wrap v1 is intentionally looser and
+// may still return the legacy id field or omit externalId.
+interface PlaygamaStoredPurchase extends AnyRecord {
+    id?: string
     orderId?: string
-    error?: unknown
+    externalId?: string
+    bridgeId?: string
     [key: string]: unknown
 }
 
 interface PlaygamaProductData extends AnyRecord {
     id: string
+    amount: number
+    description?: string
     externalId?: string
     bridgeId?: string
 }
@@ -61,7 +80,7 @@ interface PlaygamaSdk {
         getIsPaymentsSupported?: () => boolean
         getIsPlayerAuthorizationSupported?: () => boolean
         getIsCloudSaveSupported?: () => boolean
-        getAdditionalParams?: () => Record<string, unknown> | null
+        getAdditionalParams?: () => Record<string, unknown> | null | undefined
     }
     advService: {
         subscribeToAdStateChanges(callback: (adType: AdType, state: AdState) => void): void
@@ -85,9 +104,9 @@ interface PlaygamaSdk {
     }
     inGamePaymentsApi: {
         purchase(product: PlaygamaProductData): Promise<PlaygamaPurchase>
-        getPurchases?: () => Promise<Array<AnyRecord & { id: string; bridgeId?: string }>>
-        consumePurchase?: (orderId: string | undefined, externalId: string | undefined) => Promise<unknown>
-        confirmDelivery?: (params: { orderId?: string; externalId?: string }) => Promise<unknown>
+        getPurchases?: () => Promise<PlaygamaStoredPurchase[]>
+        consumePurchase?: (orderId: string, externalId?: string) => Promise<unknown>
+        confirmDelivery?: (params: { orderId: string; externalId: string }) => Promise<unknown>
     }
     gameService: {
         gameReady(): void
@@ -264,7 +283,10 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
                 return Promise.resolve()
             }
             default: {
-                (this._platformSdk as PlaygamaSdk).gameService?.sendMessage?.(String(message), (options ?? {}) as AnyRecord)
+                (this._platformSdk as PlaygamaSdk).gameService?.sendMessage?.(
+                    String(message),
+                    (options ?? {}) as AnyRecord,
+                )
                 return super.sendMessage(message, options)
             }
         }
@@ -371,14 +393,11 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
             return Promise.reject()
         }
 
-        if (options && options.externalId) {
-            product.externalId = options.externalId
-        }
+        const externalId = options?.externalId
+            ?? product.externalId
+            ?? this._paymentsGenerateTransactionId(id)
 
-        if (!product.externalId) {
-            product.externalId = this._paymentsGenerateTransactionId(id)
-        }
-
+        product.externalId = externalId
         product.bridgeId = id
 
         let promiseDecorator = this._getPromiseDecorator(ACTION_NAME.PURCHASE)
@@ -389,12 +408,17 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
             sdk.inGamePaymentsApi.purchase(product)
                 .then((purchase) => {
                     if (purchase.status === 'PAID') {
-                        const mergedPurchase: AnyRecord & { id: string } = { id, ...purchase }
+                        const purchaseExternalId = purchase.externalId ?? externalId
+                        const mergedPurchase: AnyRecord & { id: string } = {
+                            ...purchase,
+                            id,
+                            externalId: purchaseExternalId,
+                        }
                         this._paymentsPurchases.push(mergedPurchase)
                         if (sdk.inGamePaymentsApi.confirmDelivery) {
                             sdk.inGamePaymentsApi.confirmDelivery({
                                 orderId: purchase.orderId,
-                                externalId: mergedPurchase.externalId as string | undefined,
+                                externalId: purchaseExternalId,
                             }).catch(() => { /* purchase is resolved regardless */ })
                         }
                         this._resolvePromiseDecorator(ACTION_NAME.PURCHASE, mergedPurchase)
@@ -417,9 +441,30 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
 
             sdk.inGamePaymentsApi.getPurchases()
                 .then((purchases) => {
-                    this._paymentsPurchases = purchases.map(({ bridgeId, ...purchase }) => (
-                        bridgeId ? { ...purchase, id: bridgeId } : purchase
-                    ))
+                    this._paymentsPurchases = purchases.flatMap(({ bridgeId, ...purchase }) => {
+                        let orderId: string | undefined
+                        if (typeof purchase.orderId === 'string') {
+                            orderId = purchase.orderId
+                        } else if (typeof purchase.id === 'string') {
+                            orderId = purchase.id
+                        }
+
+                        let id = bridgeId
+                        if (!id && typeof purchase.id === 'string') {
+                            id = purchase.id
+                        }
+                        id ??= orderId
+
+                        if (!id) {
+                            return []
+                        }
+
+                        return [{
+                            ...purchase,
+                            id,
+                            ...(orderId ? { orderId } : {}),
+                        }]
+                    })
                     this._resolvePromiseDecorator(ACTION_NAME.GET_PURCHASES, this._paymentsPurchases)
                 })
                 .catch(() => {
@@ -433,17 +478,23 @@ class PlaygamaPlatformBridge extends PlatformBridgeBase {
     }
 
     paymentsConsumePurchase(id: string): Promise<unknown> {
-        type PurchaseRecord = AnyRecord & { id: string; orderId?: string; externalId?: string }
+        type PurchaseRecord = AnyRecord & { id: string; orderId?: unknown; externalId?: unknown }
         const purchase = this._paymentsPurchases.find((p) => p.id === id) as PurchaseRecord | undefined
         if (!purchase) {
             return Promise.reject()
+        }
+
+        const orderId = typeof purchase.orderId === 'string' ? purchase.orderId : purchase.id
+        const externalId = typeof purchase.externalId === 'string' ? purchase.externalId : undefined
+        if (!orderId || (this.platformId === PLATFORM_ID.PLAYGAMA && !externalId)) {
+            return Promise.reject(new Error('Purchase receipt is missing required platform identifiers'))
         }
 
         const sdk = this._platformSdk as PlaygamaSdk
         if (sdk.inGamePaymentsApi.consumePurchase) {
             const promiseDecorator = this._createPromiseDecorator(ACTION_NAME.CONSUME_PURCHASE)
 
-            sdk.inGamePaymentsApi.consumePurchase(purchase.orderId, purchase.externalId)
+            sdk.inGamePaymentsApi.consumePurchase(orderId, externalId)
                 .then(() => {
                     const idx = this._paymentsPurchases.findIndex((p) => p.id === id)
                     if (idx >= 0) {

--- a/tests/src/platform-bridges/playgamaPlatformBridge.spec.ts
+++ b/tests/src/platform-bridges/playgamaPlatformBridge.spec.ts
@@ -1,0 +1,136 @@
+import {
+    describe, expect, test, vi,
+} from 'vitest'
+import PlaygamaPlatformBridge from '../../../src/platform-bridges/PlaygamaPlatformBridge'
+import { PLATFORM_ID } from '../../../src/modules/platform/constants'
+
+class TestPlaygamaPlatformBridge extends PlaygamaPlatformBridge {
+    #product: Record<string, unknown> | null = null
+
+    setPlatformSdk(sdk: unknown): void {
+        this._platformSdk = sdk
+    }
+
+    setProduct(product: Record<string, unknown>): void {
+        this.#product = product
+    }
+
+    setPurchases(purchases: Array<Record<string, unknown> & { id: string }>): void {
+        this._paymentsPurchases = purchases
+    }
+
+    protected _paymentsGetProductPlatformData(): Record<string, unknown> | null {
+        return this.#product
+    }
+
+    protected _paymentsGenerateTransactionId(): string {
+        return 'generated-external-id'
+    }
+}
+
+describe('PlaygamaPlatformBridge payments', () => {
+    test('preserves the generated external id on a paid purchase', async () => {
+        const purchase = vi.fn().mockResolvedValue({
+            status: 'PAID',
+            orderId: 'order-1',
+            amount: 100,
+        })
+        const confirmDelivery = vi.fn().mockResolvedValue(undefined)
+        const bridge = new TestPlaygamaPlatformBridge()
+        bridge.setProduct({ id: 'coins', amount: 100 })
+        bridge.setPlatformSdk({ inGamePaymentsApi: { purchase, confirmDelivery } })
+
+        await expect(bridge.paymentsPurchase('coins')).resolves.toEqual({
+            id: 'coins',
+            status: 'PAID',
+            orderId: 'order-1',
+            amount: 100,
+            externalId: 'generated-external-id',
+        })
+        expect(purchase).toHaveBeenCalledWith({
+            id: 'coins',
+            amount: 100,
+            bridgeId: 'coins',
+            externalId: 'generated-external-id',
+        })
+        expect(confirmDelivery).toHaveBeenCalledWith({
+            orderId: 'order-1',
+            externalId: 'generated-external-id',
+        })
+    })
+
+    test('uses the order id when a restored purchase has no bridge id', async () => {
+        const getPurchases = vi.fn().mockResolvedValue([
+            {
+                orderId: 'order-1',
+                externalId: 'external-1',
+                bridgeId: 'coins',
+            },
+            {
+                orderId: 'order-2',
+                externalId: 'external-2',
+            },
+            {
+                id: 'legacy-order',
+            },
+        ])
+        const bridge = new TestPlaygamaPlatformBridge()
+        bridge.setPlatformSdk({ inGamePaymentsApi: { getPurchases } })
+
+        await expect(bridge.paymentsGetPurchases()).resolves.toEqual([
+            {
+                id: 'coins',
+                orderId: 'order-1',
+                externalId: 'external-1',
+            },
+            {
+                id: 'order-2',
+                orderId: 'order-2',
+                externalId: 'external-2',
+            },
+            {
+                id: 'legacy-order',
+                orderId: 'legacy-order',
+            },
+        ])
+    })
+
+    test('does not consume a receipt without its platform identifiers', async () => {
+        const consumePurchase = vi.fn().mockResolvedValue(undefined)
+        const bridge = new TestPlaygamaPlatformBridge()
+        bridge.setPurchases([{ id: 'coins', orderId: 'order-1' }])
+        bridge.setPlatformSdk({ inGamePaymentsApi: { consumePurchase } })
+
+        await expect(bridge.paymentsConsumePurchase('coins')).rejects.toThrow(
+            'Purchase receipt is missing required platform identifiers',
+        )
+        expect(consumePurchase).not.toHaveBeenCalled()
+    })
+
+    test('passes complete platform identifiers when consuming a purchase', async () => {
+        const consumePurchase = vi.fn().mockResolvedValue(undefined)
+        const bridge = new TestPlaygamaPlatformBridge()
+        bridge.setPurchases([
+            {
+                id: 'coins',
+                orderId: 'order-1',
+                externalId: 'external-1',
+            },
+        ])
+        bridge.setPlatformSdk({ inGamePaymentsApi: { consumePurchase } })
+
+        await expect(bridge.paymentsConsumePurchase('coins')).resolves.toEqual({ id: 'coins' })
+        expect(consumePurchase).toHaveBeenCalledWith('order-1', 'external-1')
+    })
+
+    test('keeps legacy Wrap receipts consumable without an external id', async () => {
+        const consumePurchase = vi.fn().mockResolvedValue(undefined)
+        const bridge = new TestPlaygamaPlatformBridge()
+        Object.defineProperty(bridge, 'platformId', { value: PLATFORM_ID.STANDALONE })
+        bridge.setPurchases([{ id: 'order-1' }])
+        bridge.setPlatformSdk({ inGamePaymentsApi: { consumePurchase } })
+
+        await expect(bridge.paymentsConsumePurchase('order-1')).resolves.toEqual({ id: 'order-1' })
+        expect(consumePurchase).toHaveBeenCalledWith('order-1', undefined)
+    })
+})


### PR DESCRIPTION
## Summary

- align Playgama advertisement, platform, and payment adapter types with the portal v1 wire contract
- preserve generated external IDs through purchase confirmation and consumption
- reject incomplete Playgama receipts before invoking consumption
- add purchase, restore, and consumption regression tests

